### PR TITLE
Release a tarball artifact

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -31,6 +31,14 @@ jobs:
       git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
 
+      - name: Set DATE environment variable
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      - name: Set archive environment variables
+        run: |
+          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -61,12 +69,13 @@ jobs:
 
       - name: Extract artifact and attestation
         run: |
-          mkdir -p ~/build/
-          cp ${{ steps.certificate.outputs.bundle-path }} result/bin/dune ~/build/
+          mkdir -p ~/$ARCHIVE_DIR/
+          cp ${{ steps.certificate.outputs.bundle-path }} result/bin/dune ~/$ARCHIVE_DIR/
+          tar -czvf ~/$ARCHIVE_TARGZ -C ~ $ARCHIVE_DIR
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ~/build/*
+          path: ~/${{ env.ARCHIVE_TARGZ }}
           name: ${{ matrix.name }}
 
 
@@ -87,6 +96,14 @@ jobs:
     needs: binary
     steps:
 
+      - name: Set DATE environment variable
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      - name: Set archive environment variables
+        run: |
+          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -94,8 +111,9 @@ jobs:
 
       - name: Get dune accessible
         run: |
-          mv ./${{ matrix.name }}/dune ./dune
-          chmod u+x ./dune
+          mv ${{ matrix.name }}/$ARCHIVE_TARGZ .
+          tar -xvf $ARCHIVE_TARGZ
+          mv ./$ARCHIVE_DIR/dune ./dune
 
       - name: Check dune is working
         run: |


### PR DESCRIPTION
This changes the github action to upload a tarball named like dune-2024-09-25-aarch64-apple-darwin.tar.gz. Extracting the tarball produces a directory named like dune-2024-09-25-aarch64-apple-darwin which contains the dune binary and the attestation file. This has several benefits over the current approach where users are required to download a dune exe directly:
 - the executable bit remains set on the dune executable inside the tarball, so users don't need to chmod the binary
 - the name of the downloaded file contains more information and is unique for each day so your downloads directory doesn't end up filled with files named "dune", "dune(1)", "dune(2)", etc.
 - we have the flexibility to add more files to the archive in the future, such as including a readme file

Currently this just updates the github action - not the website - so this can't be merged as is. I'm opening this for review in its current state to get early feedback and to see if the deploy step of the github action works as expected (I couldn't figure out how to test this on my fork).