### PR TITLE
feat: build and use tarballs on install

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ocaml/dune
-          ref: main # At some point we might need to change it to point to a developer preview branch
+          ref: main
           fetch-depth: 0 # for git describe
 
       - uses: cachix/install-nix-action@v22
@@ -67,15 +67,19 @@ jobs:
           subject-path: "result/bin/dune"
           show-summary: false
 
+      # TODO: remove the extra Dune file when the complete move to tar is done.
       - name: Extract artifact and attestation
         run: |
-          mkdir -p ~/$ARCHIVE_DIR/
-          cp ${{ steps.certificate.outputs.bundle-path }} result/bin/dune ~/$ARCHIVE_DIR/
-          tar -czvf ~/$ARCHIVE_TARGZ -C ~ $ARCHIVE_DIR
+          mkdir -p ~/build/$ARCHIVE_DIR/
+          cp ${{ steps.certificate.outputs.bundle-path }} ~/build
+          cp result/bin/dune ~/build/$ARCHIVE_DIR
+          cp result/bin/dune ~/build/
+          tar -czvf ~/build/$ARCHIVE_TARGZ -C ~/build $ARCHIVE_DIR
+          rm -rf ~/build/$ARCHIVE_DIR
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ~/${{ env.ARCHIVE_TARGZ }}
+          path: ~/build
           name: ${{ matrix.name }}
 
 
@@ -122,8 +126,6 @@ jobs:
             dune pkg lock
             dune build
 
-
-
   deploy-s3:
     runs-on: ubuntu-latest
     needs: [binary, check-artifacts]
@@ -168,6 +170,7 @@ jobs:
       - name: Move artifacts to scope
         run: mv "/home/runner/artifacts" "."
 
+
       - name: Export Rclone configuration
         run: echo "${{ secrets.RCLONE_CONF }}" >> rclone.conf
 
@@ -179,7 +182,7 @@ jobs:
       - name: Commit changes to branch
         run: |
           git config --global user.name 'Sandworm'
-          git config --global user.email 'tarides@users.noreply.github.com'
+          git config --global user.email 'ocaml-dune@users.noreply.github.com'
           (git add index.html metadata.json && \
           git commit -m "Nightly build $(date +'%Y-%m-%d')" && \
           git push) || echo "No new data" # Prevent from committing empty stuff

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -31,6 +31,14 @@ jobs:
       git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
 
+      - name: Set DATE environment variable
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      - name: Set archive environment variables
+        run: |
+          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -61,12 +69,13 @@ jobs:
 
       - name: Extract artifact and attestation
         run: |
-          mkdir -p ~/build/
-          cp ${{ steps.certificate.outputs.bundle-path }} result/bin/dune ~/build/
+          mkdir -p ~/$ARCHIVE_DIR/
+          cp ${{ steps.certificate.outputs.bundle-path }} result/bin/dune ~/$ARCHIVE_DIR/
+          tar -czvf ~/$ARCHIVE_TARGZ -C ~ $ARCHIVE_DIR
 
       - uses: actions/upload-artifact@v4
         with:
-          path: ~/build/*
+          path: ~/${{ env.ARCHIVE_TARGZ }}
           name: ${{ matrix.name }}
 
 
@@ -87,6 +96,14 @@ jobs:
     needs: binary
     steps:
 
+      - name: Set DATE environment variable
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      - name: Set archive environment variables
+        run: |
+          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -94,8 +111,9 @@ jobs:
 
       - name: Get dune accessible
         run: |
-          mv ./${{ matrix.name }}/dune ./dune
-          chmod u+x ./dune
+          mv ${{ matrix.name }}/$ARCHIVE_TARGZ .
+          tar -xvf $ARCHIVE_TARGZ
+          mv ./$ARCHIVE_DIR/dune ./dune
 
       - name: Check dune is working
         run: |

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -74,7 +74,7 @@ jobs:
           cp ${{ steps.certificate.outputs.bundle-path }} ~/build
           cp result/bin/dune ~/build/$ARCHIVE_DIR
           cp result/bin/dune ~/build/
-          tar -czvf ~/build/$ARCHIVE_TARGZ -C ~/build $ARCHIVE_DIR
+          tar --format=posix -cvf - -C ~/build $ARCHIVE_DIR | gzip -9 > "~/build/$ARCHIVE_TARGZ"
           rm -rf ~/build/$ARCHIVE_DIR
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -36,8 +36,9 @@ jobs:
 
       - name: Set archive environment variables
         run: |
-          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
           echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
+          echo "ARCHIVE_TAR=dune-$DATE-${{ matrix.name }}.tar" >> $GITHUB_ENV
+          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,7 +75,8 @@ jobs:
           cp ${{ steps.certificate.outputs.bundle-path }} ~/build
           cp result/bin/dune ~/build/$ARCHIVE_DIR
           cp result/bin/dune ~/build/
-          tar --format=posix -cvf - -C ~/build $ARCHIVE_DIR | gzip -9 > "~/build/$ARCHIVE_TARGZ"
+          tar --format=posix -cvf ~/build/$ARCHIVE_TAR -C ~/build $ARCHIVE_DIR
+          gzip -9 ~/build/$ARCHIVE_TAR
           rm -rf ~/build/$ARCHIVE_DIR
 
       - uses: actions/upload-artifact@v4

--- a/install
+++ b/install
@@ -55,27 +55,46 @@ case $(uname -ms) in
 esac
 
 today=$(date +"%Y-%m-%d")
-dune_uri="https://get.dune.build/$today/$target/dune"
+tar_target_name="dune-$today-$target"
+tar_target="$tar_target_name.tar.gz"
+dune_tar_uri="https://get.dune.build/$today/$target/$tar_target"
 
 install_dir=$HOME/.dune
 bin_dir=$install_dir/bin
+tmp_dir=$install_dir/tmp
 exe=$bin_dir/dune
+tmp_tar="$tmp_dir/$tar_target"
+tmp_tar_dir="$tmp_dir/$tar_target_name"
+tmp_exe="$tmp_tar_dir/dune"
 tilde_bin_dir=$(tildify $bin_dir)
+
+command -v tar >/dev/null 2>&1 ||
+    error "Failed to find tar. This script needs tar to be able to install dune."
 
 if [[ ! -d $bin_dir ]]; then
     mkdir -p "$bin_dir" ||
         error "Failed to create install directory \"$bin_dir\""
 fi
 
-curl --fail --location --progress-bar --output "$exe" "$dune_uri" ||
-    error "Failed to download dune from \"$dune_uri\""
+if [[ ! -d $tmp_dir ]]; then
+    mkdir -p "$tmp_dir" ||
+        error "Failed to create temporary directory \"$tmp_dir\""
+fi
 
-chmod +x "$exe" ||
-    error 'Failed to set permissions on dune executable'
+curl --fail --location --progress-bar --output "$tmp_tar" "$dune_tar_uri" ||
+    error "Failed to download dune tar from \"$dune_tar_uri\""
+
+tar -xvf "$tmp_tar" -C $tmp_dir 2>&1 > /dev/null ||
+    error "Failed to extract dune archive content from \"$tmp_tar\""
+
+mv $tmp_exe $exe ||
+    error "Failed to move executable from $tmp_exe to $exe"
+
+(rm "$tmp_tar" && rmdir "$tmp_tar_dir" && rmdir "$tmp_dir") ||
+    error "Failed to delete the temporary directory $tmp_dir"
 
 
-
-success "dune was installed successfully to $Bold_Green$(tildify "$exe")"
+success "dune $target was installed successfully to $Bold_Green$(tildify "$exe")"
 
 echo
 


### PR DESCRIPTION
This PR superseeds #38. It was tested using this [GitHub actions](https://github.com/ocaml-dune/binary-distribution/actions/runs/11139847470/job/30957906388). It adds an update to the install script to build dune from the tarball now. Some changes are kept so the website keep running (still embedding the executable). Future PRs will remove this when the design of the website will be completed :+1: 