### PR TITLE
feat: support new dune.build URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM nginx:1.27-alpine
-COPY ./main.css ./index.html ./install /usr/share/nginx/html/
+COPY ./main.css ./index.html /usr/share/nginx/html/
 CMD [ "nginx", "-g", "daemon off;" ]

--- a/install
+++ b/install
@@ -55,7 +55,7 @@ case $(uname -ms) in
 esac
 
 today=$(date +"%Y-%m-%d")
-dune_uri="https://download.dune.ci.dev/$today/$target/dune"
+dune_uri="https://get.dune.build/$today/$target/dune"
 
 install_dir=$HOME/.dune
 bin_dir=$install_dir/bin

--- a/sandworm/bin/config.ml
+++ b/sandworm/bin/config.ml
@@ -1,6 +1,6 @@
 module Server = struct
   let rclone_bucket_ref = "dune-binary-distribution:/dune/"
-  let url = "https://download.dune.ci.dev"
+  let url = "https://get.dune.build"
 end
 
 module Path = struct

--- a/sandworm/bin/config.ml
+++ b/sandworm/bin/config.ml
@@ -1,5 +1,6 @@
 module Server = struct
-  let rclone_bucket_ref = "dune-binary-distribution:/dune/"
+  let bucket_dir = "/dune/"
+  let rclone_bucket_ref = Format.sprintf "dune-binary-distribution:%s" bucket_dir
   let url = "https://get.dune.build"
 end
 
@@ -7,5 +8,6 @@ module Path = struct
   let artifacts_dir = "./artifacts"
   let metadata = "./metadata.json"
   let rclone = "./rclone.conf"
+  let install = "./install"
   let html_index = "./index.html"
 end

--- a/sandworm/bin/config.ml
+++ b/sandworm/bin/config.ml
@@ -1,6 +1,11 @@
-let s3_bucket_ref = "dune-binary-distribution:/dune/"
-let s3_public_url = "https://download.dune.ci.dev"
-let artifacts_path = "./artifacts"
-let metadata_file = "./metadata.json"
-let rclone_file = "./rclone.conf"
-let html_file = "./index.html"
+module Server = struct
+  let rclone_bucket_ref = "dune-binary-distribution:/dune/"
+  let url = "https://download.dune.ci.dev"
+end
+
+module Path = struct
+  let artifacts_dir = "./artifacts"
+  let metadata = "./metadata.json"
+  let rclone = "./rclone.conf"
+  let html_index = "./index.html"
+end

--- a/sandworm/bin/main.ml
+++ b/sandworm/bin/main.ml
@@ -4,12 +4,12 @@ open Cmdliner
 module Common_args = struct
   let html_file =
     let doc = "The file where to export the HTML code." in
-    Arg.(value & opt string Config.html_file & info ~doc [ "html" ])
+    Arg.(value & opt string Config.Path.html_index & info ~doc [ "html" ])
   ;;
 
   let metadata_file =
     let doc = "The JSON file to import the data from." in
-    Arg.(value & opt string Config.metadata_file & info ~doc [ "metadata" ])
+    Arg.(value & opt string Config.Path.metadata & info ~doc [ "metadata" ])
   ;;
 
   let commit =
@@ -27,7 +27,7 @@ module Gen_html = struct
   let generate_website html_file metadata_file =
     Format.printf "--> Generate the index %s\n" html_file;
     let bundles = Metadata.import_from_json metadata_file in
-    Web.export_bundle_to_file ~base_url:Config.s3_public_url ~file:html_file bundles;
+    Web.export_bundle_to_file ~base_url:Config.Server.url ~file:html_file bundles;
     Format.printf "--> Completed ✓\n"
   ;;
 
@@ -54,17 +54,17 @@ module Sync = struct
       Metadata.(Bundle.create_daily ~commit Target.defaults)
     in
     let daily_bundle_date = Metadata.Bundle.get_date_string_from daily_bundle in
-    let s3_daily_bundle = Filename.concat Config.s3_bucket_ref daily_bundle_date in
+    let s3_daily_bundle = Filename.concat Config.Server.rclone_bucket_ref daily_bundle_date in
     let () =
       if dry_run
       then
         Format.printf
           "- Copy files from path (%s) to %s, using RClone (%s)\n"
-          Config.artifacts_path
+          Config.Path.artifacts_dir
           s3_daily_bundle
-          Config.rclone_file
+          Config.Path.rclone
       else
-        Rclone.copy ~config_path:Config.rclone_file Config.artifacts_path s3_daily_bundle
+        Rclone.copy ~config_path:Config.Path.rclone Config.Path.artifacts_dir s3_daily_bundle
     in
     let bundles = Metadata.insert_unique daily_bundle bundle in
     let () =
@@ -75,7 +75,7 @@ module Sync = struct
     let () =
       if dry_run
       then Format.printf "- Export HTML code to %s\n" html_file
-      else Web.export_bundle_to_file ~base_url:Config.s3_public_url ~file:html_file bundles
+      else Web.export_bundle_to_file ~base_url:Config.Server.url ~file:html_file bundles
     in
     Format.printf "--> Completed ✓\n"
   ;;

--- a/sandworm/lib/rclone.ml
+++ b/sandworm/lib/rclone.ml
@@ -12,11 +12,13 @@ let run cmd args =
     raise (Invalid_argument (Format.sprintf "--> Command stopped by signal %d" signal))
 ;;
 
+(* It uses rclone copyto as it also allows us to copy one file if [src] points
+   to a file. In case [src] is a directory, it behaves exactly like copy. *)
 let copy ~config_path src dest =
   let cmd = "rclone" in
   let args =
     [| "rclone"
-     ; "copy"
+     ; "copyto"
      ; "-v"
      ; "--config"
      ; Unix.realpath config_path

--- a/sandworm/lib/web.mlx
+++ b/sandworm/lib/web.mlx
@@ -1,5 +1,7 @@
 module Info = struct
   let title = "Dune Developer Preview"
+  let curl_with_bash url =
+      Format.sprintf "curl %s | bash" url  |> JSX.string
 end
 
 module Icons = struct
@@ -50,7 +52,7 @@ let navbar () =
     </div>
   </nav>
 
-let getting_started () =
+let getting_started ~install_url () =
   <section class_="flex flex-col pt-10 gap-2">
     <h4 class_="text-md font-regular rounded bg-gray-900 text-white w-fit px-2 py-[0.5]"> "Dune Developer Preview" </h4>
     <h1 class_="text-6xl font-black pb-4"> "Setup OCaml in under a minute" </h1>
@@ -67,7 +69,7 @@ let getting_started () =
     <div class_="flex flex-row gap-4 items-center rounded pt-2 pb-5">
       <div class_="pl-4 bg-gray-100 flex flex-row items-center gap-2">
         <span id="install-cmd" class_="pr-2 font-mono">
-          "curl https://dune.ci.dev/install | bash"
+          (Info.curl_with_bash install_url)
         </span>
         <Icons.copy id="copy-btn" class_="rounded-tr rounded-br cursor-pointer" />
         <Icons.ok id="ok-btn" class_="rounded-tr rounded-br cursor-pointer hidden" />
@@ -297,6 +299,7 @@ $ gh attestation verify ./dune -R tarides/dune-binary-distribution --bundle atte
   </section>
 
 let page ~base_url releases =
+  let install_url = Filename.concat base_url "install" in
   <html>
     <head>
       <meta charset="utf-8" />
@@ -310,7 +313,7 @@ let page ~base_url releases =
     <body class_="w-full flex flex-col overflow-scroll justify-center items-center">
       <navbar />
       <section class_="flex flex-col w-full px-4 lg:max-w-screen-xl">
-        <getting_started />
+        <getting_started install_url />
         <faq />
         <manual_installation base_url releases />
       </section>


### PR DESCRIPTION
This PR updates various parts of the project to support new URLS:
- It moves the bucket from download.dune.ci.dev to get.dune.build
- It changes the code to also upload the `install` file to the bucket

I have also changed the configuration in GitHub Actions to push the new binaries to get.dune.build. These changes are related to building the website with OCurrent and deploy to the new URLs to make the preview of Dune officially public. It is related to https://github.com/ocurrent/ocurrent-deployer/issues/235.