### PR TITLE
fix: legacy install support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM nginx:1.27-alpine
-COPY ./main.css ./index.html /usr/share/nginx/html/
+COPY ./main.css ./index.html ./install /usr/share/nginx/html/
 CMD [ "nginx", "-g", "daemon off;" ]


### PR DESCRIPTION
Removing the install script from the Dockerfile (as it was moved to the bucket) makes the people using the legacy version to lose the script.