### PR TITLE
More secure curl options

### DIFF
--- a/sandworm/lib/web.mlx
+++ b/sandworm/lib/web.mlx
@@ -1,7 +1,7 @@
 module Info = struct
   let title = "Dune Developer Preview"
   let curl_with_bash url =
-      Format.sprintf "curl %s | bash" url  |> JSX.string
+    Format.sprintf "curl -fsSL %s | bash" url  |> JSX.string
 end
 
 module Icons = struct


### PR DESCRIPTION
This adds more options to `curl` to fail in a more sensible way if there are issues. Especially the `-L` option would've been useful as we have set up a redirect.

Convienient explanation of the options in question by [explainshell curl -fsSL](https://explainshell.com/explain?cmd=curl+-fsSL)