### PR TITLE
Readable colours on dark terminals

### DIFF
--- a/static/install
+++ b/static/install
@@ -12,7 +12,7 @@ Color_Off='\033[0m' # Text Reset
 # Regular Colors
 Red='\033[0;31m'   # Red
 Green='\033[0;32m' # Green
-Dim='\033[0;2m'    # White
+White='\033[0;0m'  # White
 
 # Bold
 Bold_Green='\033[1;32m' # Bold Green
@@ -24,7 +24,7 @@ error() {
 }
 
 info() {
-    echo -e "${Dim}$* ${Color_Off}"
+    echo -e "${White}$* ${Color_Off}"
 }
 
 info_bold() {


### PR DESCRIPTION
![screenshot](https://github.com/user-attachments/assets/3327b50c-6928-4b77-adc5-628df6b57ae3)

The dim text was hard to read on dark themed terminals. I've tested this change on light and dark terminals and the result is more readable.