### PR TITLE
fix: don't try to push index.html

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -178,7 +178,7 @@ jobs:
         run: |
           git config --global user.name 'Sandworm'
           git config --global user.email 'ocaml-dune@users.noreply.github.com'
-          (git add index.html metadata.json && \
+          (git add metadata.json && \
           git commit -m "Nightly build $(date +'%Y-%m-%d')" && \
           git push) || echo "No new data" # Prevent from committing empty stuff
 


### PR DESCRIPTION
This PR fixes an issue in the PR that moves to `dream`. As it does not generate an `index.html` the CI wasn't working anymore.