### PR TITLE
Avoid unnecessary builds if no changes happened since last run

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   binary:
-    name: Create
+    name: Create the dune binary
     permissions:
       id-token: write
       attestations: write
@@ -30,7 +30,10 @@ jobs:
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
+      - name: Count commits in last 24 hours
+        run: echo "COMMITS_LAST_DAY=$(git log --oneline --since='24 hours ago' -1)" >> $GITHUB_ENV
       - name: Set DATE environment variable
+        if: ${{ env.COMMITS_LAST_DAY != "" }}
         run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
       - name: Set archive environment variables

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -26,14 +26,14 @@ jobs:
             name: x86_64-unknown-linux-musl
             installable: .#dune-static-experimental
 
+    # If the latest commit is the same as latest run, don't re-run.
+    if: (git log --format=%H -1) != (jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
+
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
-      - name: Count commits in last 24 hours
-        run: echo "COMMITS_LAST_DAY=$(git log --oneline --since='24 hours ago' -1)" >> $GITHUB_ENV
       - name: Set DATE environment variable
-        if: ${{ env.COMMITS_LAST_DAY != "" }}
         run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
       - name: Set archive environment variables

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   binary:
-    name: Create the dune binary
+    name: Create the artifact
     permissions:
       id-token: write
       attestations: write
@@ -27,7 +27,7 @@ jobs:
             installable: .#dune-static-experimental
 
     # If the latest commit is the same as latest run, don't re-run.
-    if: (git log --format=%H -1) != (jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
+    if: (git rev-parse HEAD) != (jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
 
     runs-on: ${{ matrix.os }}
     outputs:


### PR DESCRIPTION
This is an attempt at fixing #45.
In the issue @Leonidas-from-XIV raises a good point: if the previous run wasn't 24h ago for some reason, then this will make it wait until a new commit. This isn't ideal, but there is no direct way in github actions to get the status of the previous run. A solution may be to hit the github api and ask there, but that requires a token which we may or may not have.
Another would be to ask around the system where we put the previous binaries, and compute the time difference...
Just wanted to get the ball rolling 