### PR TITLE
Add minimal shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    opam
+    pkg-config
+    gmp
+    openssl
+    libev
+  ];
+}


### PR DESCRIPTION
The shell.nix file contains all system packages needed to build/run the opam packages which this project depends on.