### PR TITLE
Use posix args to `date` in github action

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Export version
         run: |
-          echo "(version \"Dune Developer Preview: build $(date --iso-8601=seconds), git revision $(git rev-parse HEAD)\")" >> dune-project
+          echo "(version \"Dune Developer Preview: build $(date -u +"%Y-%m-%dT%H:%M:%SZ"), git revision $(git rev-parse HEAD)\")" >> dune-project
 
       - run: nix build ${{ matrix.installable }}
 


### PR DESCRIPTION
This fixes a bug where the build time is missing from version numbers on macOS. The build time is missing because the `date` command on macOS is not the gnu implementation, so lacks the `--iso-8601` argument, causing the command to fail. The fix is to explicitly describe a date format which is very close to ISO8601, the one difference being that it uses a "Z" to denote the UTC timezone.