### PR TITLE
fix: push the script to the root location

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -53,7 +53,9 @@ module Sync = struct
     in
     let () =
       let install_bucket_path =
-        Filename.concat Config.Server.rclone_bucket_ref Config.Path.install
+        Filename.concat
+          Config.Server.rclone_bucket_ref
+          (Filename.basename Config.Path.install)
       in
       if dry_run
       then


### PR DESCRIPTION
The reason why we weren't able to access the script was just because it was pushed to the wrong directory. I have missed this while changing the structure to use Dream.