### PR TITLE
feat: return latest url

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -97,9 +97,11 @@ end
 
 module Http = struct
   let serve dev metadata_file port =
+    let base_url = Config.Server.url in
     let bundles = Metadata.import_from_json metadata_file in
-    let content = Web.export_bundle_to_string ~base_url:Config.Server.url bundles in
-    Server.serve ~dev content port
+    let content = Web.export_bundle_to_string ~base_url bundles in
+    let latest = List.hd bundles in
+    Server.serve ~dev ~base_url content port latest
   ;;
 
   let term =

--- a/bin/server.ml
+++ b/bin/server.ml
@@ -13,7 +13,17 @@ let reload_script_middleware ~dev inner_handler request =
   if dev then Dream.livereload inner_handler request else inner_handler request
 ;;
 
-let serve ~dev site port =
+let latest_route_from_targets ~base_url bundle =
+  let open Sandworm.Metadata in
+  List.map
+    (fun target ->
+      let path = Format.sprintf "/%s" (Target.to_string target) in
+      Dream.get path (fun _ ->
+        Dream.html (Bundle.to_download_url ~base_url ~target bundle)))
+    bundle.targets
+;;
+
+let serve ~dev ~base_url site port bundle =
   let interface = if dev then "127.0.0.1" else "0.0.0.0" in
   Dream.log
     "Server is up and running with mode %s and with css %s"
@@ -30,5 +40,6 @@ let serve ~dev site port =
        ; Dream.get "/index.html" (fun _ -> Dream.html site)
        ; Dream.get "/install" (fun request -> Dream.redirect request "/static/install")
        ; Dream.get "/static/**" @@ Dream.static "static"
+       ; Dream.scope "/latest" [] (latest_route_from_targets ~base_url bundle)
        ]
 ;;


### PR DESCRIPTION
This PR adds a new endpoint to the webserver, `/latest/<arch>`. This endpoint generates the full URL (including host) where to download the tar archive for architecture `<arch>`.
This is meant to be added to the install script to solve the timezone issue.
