### PR TITLE
fix: check_build action

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
       - id: verify
         run: |
-          LAST_COMMIT=$((jq -r ".|sort_by(.date)|last|.commit" < metadata.json))
+          LAST_COMMIT=$(jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
           if [ "$GIT_HEAD" = "$LAST_COMMIT" ] ; then
             echo "action=SKIP" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -16,14 +16,13 @@ jobs:
         with:
           repository: ocaml/dune
           ref: main
-          fetch-depth: 1 
+          fetch-depth: 1
+      - name: Export HEAD
+        run: echo "GIT_HEAD=$(git rev-parse HEAD)" > "$GITHUB_ENV"
       - name: Checkout
         uses: actions/checkout@v4
       - id: verify
         run: |
-          cd "$GITHUB_WORKSPACE/dune" 
-          GIT_HEAD=$(git rev-parse HEAD)
-          cd "$GITHUB_WORKSPACE/binary-distribution"
           LAST_COMMIT=$((jq -r ".|sort_by(.date)|last|.commit" < metadata.json))
           if [ "$GIT_HEAD" = "$LAST_COMMIT" ] ; then
             echo "action=SKIP" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -53,7 +53,7 @@ jobs:
             installable: .#dune-static-experimental
 
     # If the latest commit is the same as latest run, don't re-run.
-    if: ${{ needs.check_build.outputs.action == "BUILD" }}
+    if: ${{ needs.check_build.outputs.action == 'BUILD' }}
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -24,6 +24,7 @@ jobs:
       - id: verify
         run: |
           LAST_COMMIT=$(jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
+          echo "The commit is $LAST_COMMIT"
           if [ "$GIT_HEAD" = "$LAST_COMMIT" ] ; then
             echo "action=SKIP" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -24,7 +24,6 @@ jobs:
       - id: verify
         run: |
           LAST_COMMIT=$(jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
-          echo "The commit is $LAST_COMMIT"
           if [ "$GIT_HEAD" = "$LAST_COMMIT" ] ; then
             echo "action=SKIP" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -6,8 +6,34 @@ on:
     - cron: "0 1 * * *" # Triggers the build at 1:00 UTC time
 
 jobs:
+  check_build:
+    name: Check if we need to run the pipeline or not
+    runs-on: ubuntu-latest
+    outputs:
+      action: ${{ steps.verify.outputs.action }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ocaml/dune
+          ref: main
+          fetch-depth: 1 
+      - name: Checkout
+        uses: actions/checkout@v4
+      - id: verify
+        run: |
+          cd "$GITHUB_WORKSPACE/dune" 
+          GIT_HEAD=$(git rev-parse HEAD)
+          cd "$GITHUB_WORKSPACE/binary-distribution"
+          LAST_COMMIT=$((jq -r ".|sort_by(.date)|last|.commit" < metadata.json))
+          if [ "$GIT_HEAD" = "$LAST_COMMIT" ] ; then
+            echo "action=SKIP" >> "$GITHUB_OUTPUT"
+          else
+            echo "action=BUILD" >> "$GITHUB_OUTPUT"
+          fi
+
   binary:
     name: Create the artifact
+    needs: check_build
     permissions:
       id-token: write
       attestations: write
@@ -27,8 +53,7 @@ jobs:
             installable: .#dune-static-experimental
 
     # If the latest commit is the same as latest run, don't re-run.
-    if: (git rev-parse HEAD) != (jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
-
+    if: ${{ needs.check_build.outputs.action == "BUILD" }}
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}


### PR DESCRIPTION
This PR fixes #45 as it was not fully compliant with the GitHub Actions YAML syntax. It moves the check to a prior step instead of directly doing it in the build stage itself. I tested the actions before, and it seems to work. We will be fully confident when it will be triggered for the first time :+1:  