### PR TITLE
fix: temporary deactivate the duplication check

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -52,7 +52,7 @@ jobs:
             installable: .#dune-static-experimental
 
     # If the latest commit is the same as latest run, don't re-run.
-    if: ${{ needs.check_build.outputs.action == 'BUILD' }}
+    # if: ${{ needs.check_build.outputs.action == 'BUILD' }}
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}


### PR DESCRIPTION
This PR temporary disable the duplication check. It can be set back again when the script does not rely on the date of the day any more.

Temporary workaround for #98.