### PR TITLE
feat: update tar pipeline

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -57,14 +57,11 @@ jobs:
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}
     steps:
-      - name: Set DATE environment variable
-        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
-
       - name: Set archive environment variables
         run: |
-          echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
-          echo "ARCHIVE_TAR=dune-$DATE-${{ matrix.name }}.tar" >> $GITHUB_ENV
-          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-${{ matrix.name }}" >> $GITHUB_ENV
+          echo "ARCHIVE_TAR=dune-${{ matrix.name }}.tar" >> $GITHUB_ENV
+          echo "ARCHIVE_TARGZ=dune-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -130,8 +127,8 @@ jobs:
 
       - name: Set archive environment variables
         run: |
-          echo "ARCHIVE_TARGZ=dune-$DATE-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
-          echo "ARCHIVE_DIR=dune-$DATE-${{ matrix.name }}" >> $GITHUB_ENV
+          echo "ARCHIVE_TARGZ=dune-${{ matrix.name }}.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-${{ matrix.name }}" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v4

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -84,21 +84,16 @@ module Bundle = struct
     to_url ~base_url ~target t / "attestation.jsonl"
   ;;
 
-  let download_file_name ~date arch =
-    match date with
-    | None -> Format.sprintf "dune-%s.tar.gz" arch
-    | Some date -> Format.sprintf "dune-%s-%s.tar.gz" date arch
-  ;;
+  let download_file_name arch = Format.sprintf "dune-%s.tar.gz" arch
 
   let to_download_url ~base_url ~target t =
-    let date = get_date_string_from t |> Option.some in
     let arch = Target.to_string target in
-    to_url ~base_url ~target t / download_file_name ~date arch
+    to_url ~base_url ~target t / download_file_name arch
   ;;
 
   let to_download_file target =
     let arch = Target.to_string target in
-    download_file_name ~date:None arch
+    download_file_name arch
   ;;
 end
 


### PR DESCRIPTION
This PR is paired with #105. The goal is to remove the date from everywhere but the URLs. We don't need them in the tar file, as we have the build date encoded into the binary. 