### PR TITLE
chore(ci): reactivate build on change feature

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -52,7 +52,7 @@ jobs:
             installable: .#dune-static-experimental
 
     # If the latest commit is the same as latest run, don't re-run.
-    # if: ${{ needs.check_build.outputs.action == 'BUILD' }}
+    if: ${{ needs.check_build.outputs.action == 'BUILD' }}
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}


### PR DESCRIPTION
Since #105 have been merged, we can reintroduce this feature as we don't depend on the date any more :+1: 