### PR TITLE
chore: staging use a subdir for test

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -184,6 +184,14 @@ jobs:
           ocaml-compiler: "5.2"
           dune-cache: true
 
+      - name: Update config on test
+        if: ${{ github.ref == 'refs/heads/staging' }}
+        run: |
+          sed -i 's#let bucket_dir = .*#let bucket_dir = "/dune/test"#g' ./bin/config.ml
+          sed -i 's#let url = .*#let url = "https://get.dune.build/test"#g' ./bin/config.ml
+          git add --ignore-errors ./bin/config.ml
+          cat ./bin/config.ml
+
       - name: Install Sandworm deps && build
         run: opam install -y . --deps-only && opam exec -- dune build
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,26 @@ website.
 
 The flag `--dev` has two actions. To protect the users, it only exposes the
 server to `localhost` instead of `0.0.0.0`. Also, it injects a script in the
-page to ensure the page is reloaded when you restart the server. 
+page to ensure the page is reloaded when you restart the server.
 
 ## Deploying
+
+### Deploying on staging environment
+
+If you need to test your work, you can push on the staging environment. This
+environment is available at https://staging-preview.dune.build. If you just need
+to test the website view, you need to reset the HEAD of the `staging` branch
+and push force on it:
+```sh
+ $ git switch staging
+ $ git reset --hard <mybranch>
+ $ git push origin staging --force-with-lease # Ensure nobody is not testing in the same time
+```
+If you want to test this installation script, go to the ["binaries"
+actions](https://github.com/ocaml-dune/binary-distribution/actions/workflows/binary.yaml)
+page and run the `Run workflow` on the `staging` branch. 
+
+### Deploying in production
 
 The deployment are automatically done through GitHub Actions. No need to add
 extra work to deploy it.


### PR DESCRIPTION
This PR fixes #51. To test a branch, we can now push force on staging and, trigger the pipeline. It will push the binary to a "<url>/test/..." location. It will use sed to modify the config to point to the right bucket (the test one). This way, we can test our scripts in real-time. I agree this is not the cleanest way to have a test environment, but it is the easiest one.