### PR TITLE
Temporarily remove check_build to allow archive to be rebuilt

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -6,30 +6,6 @@ on:
     - cron: "0 1 * * *" # Triggers the build at 1:00 UTC time
 
 jobs:
-  check_build:
-    name: Check if we need to run the pipeline or not
-    runs-on: ubuntu-latest
-    outputs:
-      action: ${{ steps.verify.outputs.action }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: ocaml/dune
-          ref: main
-          fetch-depth: 1
-      - name: Export HEAD
-        run: echo "GIT_HEAD=$(git rev-parse HEAD)" > "$GITHUB_ENV"
-      - name: Checkout
-        uses: actions/checkout@v4
-      - id: verify
-        run: |
-          LAST_COMMIT=$(jq -r ".|sort_by(.date)|last|.commit" < metadata.json)
-          if [ "$GIT_HEAD" = "$LAST_COMMIT" ] ; then
-            echo "action=SKIP" >> "$GITHUB_OUTPUT"
-          else
-            echo "action=BUILD" >> "$GITHUB_OUTPUT"
-          fi
-
   binary:
     name: Create the artifact
     needs: check_build


### PR DESCRIPTION
I'll add that stage back once the build finishes, but I need this check to be disabled to rebuild the archive to include the env and completions dirs. Heads up @maiste.