### PR TITLE
Run env scripts from external files

### DIFF
--- a/static/install
+++ b/static/install
@@ -81,7 +81,6 @@ bin_dir="$install_dir/bin"
 tmp_dir="$install_dir/tmp"
 exe="$bin_dir/dune"
 tmp_tar="$tmp_dir/$tar_target"
-tilde_bin_dir=$(tildify "$bin_dir")
 
 ensure_command "tar"
 # technically gunzip probably but they will both exist
@@ -114,56 +113,78 @@ tmp_exe="$tmp_tar_dir/dune"
 mv "$tmp_exe" "$exe" ||
     error "Failed to move executable from $tmp_exe to $exe"
 
+if [ -d "$install_dir/env" ]; then
+    rm -r "$install_dir/env"
+fi
+mv "$tmp_tar_dir/env" "$install_dir" ||
+    error "Failed to move env from $tmp_tar_dir to $install_dir"
+
+if [ -d "$install_dir/completions" ]; then
+    rm -r "$install_dir/completions"
+fi
+mv "$tmp_tar_dir/completions" "$install_dir" ||
+    error "Failed to move completions from $tmp_tar_dir to $install_dir"
+
 success "dune $target was installed successfully to"
 success_bold "$(tildify "$exe")"
 echo
 echo
 
+already_installed=false
 
 case $(basename "$SHELL") in
 fish)
-    command="set --export PATH $bin_dir \$PATH"
+    env_file="\$HOME/.dune/env/env.fish"
 
     fish_config=$HOME/.config/fish/config.fish
     tilde_fish_config=$(tildify "$fish_config")
 
-    if [ -w "$fish_config" ]; then
-        printf "\n# dune\n%s\n" "$command" >> "$fish_config"
+    # deliberately omit the home directory from the pattern so "~" and "$HOME" can be used interchangeably
+    if [ -f "$fish_config" ] && match=$(grep -n ".dune/env/env.fish" "$fish_config"); then
+        echo "Shell configuration for dune appears to already exist in \"$fish_config\":"
+        echo "$match"
+        already_installed=true
+        refresh_command="source $tilde_fish_config"
+    elif [ -w "$fish_config" ]; then
+        printf "\n# dune\n%s\n" "source $env_file" >> "$fish_config"
 
-        info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_fish_config\""
+        info "Sourced \"$env_file\" in \"$tilde_fish_config\""
         echo
 
         refresh_command="source $tilde_fish_config"
     else
-        echo "Manually add the directory to $tilde_fish_config (or similar):"
-        info_bold "  $command"
+        echo "To use dune you will need to source the file \"$env_file\""
         echo
     fi
     ;;
 zsh)
 
-    command="export PATH=\"$bin_dir:\$PATH\""
+    env_file="\$HOME/.dune/env/env.zsh"
 
     zsh_config=$HOME/.zshrc
     tilde_zsh_config=$(tildify "$zsh_config")
 
-    if [ -w "$zsh_config" ]; then
-        printf "\n# dune\n%s\n" "$command" >>"$zsh_config"
+    # deliberately omit the home directory from the pattern so "~" and "$HOME" can be used interchangeably
+    if [ -f "$zsh_config" ] && match=$(grep -n ".dune/env/env.zsh" "$zsh_config"); then
+        echo "Shell configuration for dune appears to already exist in \"$zsh_config\":"
+        echo "$match"
+        already_installed=true
+        refresh_command="exec $SHELL"
+    elif [ -w "$zsh_config" ]; then
+        printf "\n# dune\n%s\n" "source $env_file" >>"$zsh_config"
 
-        info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_zsh_config\""
+        info "Sourced \"$env_file\" in \"$tilde_zsh_config\""
         echo
 
         refresh_command="exec $SHELL"
     else
-        echo "Manually add the directory to $tilde_zsh_config (or similar):"
-
-        info_bold "  $command"
+        echo "To use dune you will need to source the file \"$env_file\""
         echo
     fi
     ;;
 bash)
 
-    command="export PATH=\"$bin_dir:\$PATH\""
+    env_file="\$HOME/.dune/env/env.bash"
 
     bash_configs="$HOME/.bashrc $HOME/.bash_profile"
 
@@ -171,47 +192,62 @@ bash)
         bash_configs="$bash_configs $XDG_CONFIG_HOME/.bash_profile $XDG_CONFIG_HOME/.bashrc $XDG_CONFIG_HOME/bash_profile $XDG_CONFIG_HOME/bashrc"
     fi
 
-    set_manually=true
     for bash_config in $bash_configs; do
-        tilde_bash_config=$(tildify "$bash_config")
-
-        if [ -w "$bash_config" ]; then
-            printf "\n# dune\n%s\n" "$command" >> "$bash_config"
-
-            info "Added \"$tilde_bin_dir\" to \$PATH in \"$tilde_bash_config\""
-            echo
-
+        # deliberately omit the home directory from the pattern so "~" and "$HOME" can be used interchangeably
+        if [ -f "$bash_config" ] && match=$(grep -n ".dune/env/env.bash" "$bash_config"); then
+            echo "Shell configuration for dune appears to already exist in \"$bash_config\":"
+            echo "$match"
             refresh_command="source $bash_config"
-            set_manually=false
+            already_installed=true
             break
         fi
     done
 
-    if [ $set_manually = true ]; then
-        echo "Manually add the directory to $tilde_bash_config (or similar):"
+    if [ "$already_installed" = false ]; then
+        set_manually=true
+        for bash_config in $bash_configs; do
+            tilde_bash_config=$(tildify "$bash_config")
 
-        info_bold "  $command"
-        echo
+            if [ -w "$bash_config" ]; then
+                printf "\n# dune\n%s\n" "source $env_file" >>"$bash_config"
+
+                info "Sourced \"$env_file\" in \"$tilde_bash_config\""
+                echo
+
+                refresh_command="source $bash_config"
+                set_manually=false
+                break
+            fi
+        done
+
+        if [ $set_manually = true ]; then
+            echo "To use dune you will need to source the file \"$env_file\""
+            echo
+        fi
     fi
     ;;
 *)
-    echo 'Manually add the directory to ~/.bashrc (or similar):'
+    env_file="\$HOME/.dune/env/env.bash"
+    echo "To use dune you will need to source the file \"$env_file\" (or similar as appropriate for your shell)"
     info_bold "  export PATH=\"$bin_dir:\$PATH\""
     echo
     ;;
 esac
 
-echo
-info "To get started, run:"
-echo
 
-if [ -n "${refresh_command+x}" ]; then
-    info_bold "  $refresh_command"
+if [ "$already_installed" = false ]; then
+    echo
+    info "To get started, run:"
+    echo
+
+    if [ -n "${refresh_command+x}" ]; then
+        info_bold "  $refresh_command"
+        echo
+    fi
+
+    info_bold "  dune --help"
     echo
 fi
-
-info_bold "  dune --help"
-echo
 
 # end of main
 }


### PR DESCRIPTION
This fixes an issue where installing dune multiple times results in multiple additions to the shell rc file. The most naive way to achive this would just be to not modify the shell rc if it looks like dune has already been installed. The problem with that approach is that we may want to update the env changes in the future. Moving all env changes to a separate file sourcef from the shell rc gives us the ability to change the contents of that file in future updates without needing to modify the shell rc.

It also simplifies the install script as we no longer need to put shell commands in bash strings and deal with the complexities of escaping characters correctly.