### PR TITLE
feat: build on workflow dispatch event

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -52,7 +52,7 @@ jobs:
             installable: .#dune-static-experimental
 
     # If the latest commit is the same as latest run, don't re-run.
-    if: ${{ needs.check_build.outputs.action == 'BUILD' }}
+    if: ${{ needs.check_build.outputs.action == 'BUILD' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ matrix.os }}
     outputs:
       git-commit: ${{ steps.git-commit.outputs.hash }}


### PR DESCRIPTION
This PR ensures we are rebuilding when using the dispatch functionality of GitHub Actions. Indeed, if someone is explicitly asking to rebuild the binaries, it is consciously. We must not block the building. The smart building should only occur when using the scheduling pipeline.