### PR TITLE
Extract archives as the current user instead of the archive user

### DIFF
--- a/static/install
+++ b/static/install
@@ -97,6 +97,15 @@ ensure_command "tar"
 ensure_command "gzip"
 ensure_command "curl"
 
+# determine whether we can use --no-same-owner to force tar to extract with user permissions
+touch "${tmp_dir}/tar-detect"
+tar cf "${tmp_dir}/tar-detect.tar" -C "${tmp_dir}" tar-detect
+if tar -C "${tmp_dir}" -xf "${tmp_dir}/tar-detect.tar" --no-same-owner; then
+  tar_owner="--no-same-owner"
+else
+  tar_owner=""
+fi
+
 if [ ! -d "$bin_dir" ]; then
     mkdir -p "$bin_dir" ||
         error "Failed to create install directory \"$bin_dir\""
@@ -106,7 +115,7 @@ curl --fail --location --progress-bar --output "$tmp_tar" "$dune_tar_uri" ||
     error "Failed to download dune tar from \"$dune_tar_uri\""
 
 
-tar -xf "$tmp_tar" -C "$tmp_dir" > /dev/null 2>&1 ||
+tar -xf "$tmp_tar" -C "$tmp_dir" "${tar_owner}" > /dev/null 2>&1 ||
     error "Failed to extract dune archive content from \"$tmp_tar\""
 
 # locate the name of the directory that was unpacked in the tarball
@@ -139,7 +148,7 @@ cache_dir="${XDG_CACHE_HOME:-$HOME/.cache/dune}"
 rev_store_dir="${cache_dir}/git-repo"
 
 unpack_tar() {
-    tar xf "$1" -C "${tmp_dir}"
+    tar xf "$1" -C "${tmp_dir}" "${tar_owner}"
 }
 
 unpack_tar_zstd() {


### PR DESCRIPTION
By default files unpacked by tar are owned by the current user. But when running as root (e.g. Docker) then tar will unpack with the owner set to the owner from the tar archive instead of the user (as tar stores the UID in the metadata). This potentially leads to files with strange owners and among others, git refusing to touch the cached repository.

To take an example provided by @mefyl:
```
FROM alpine
RUN apk add bash curl git make npm gcc g++ tzdata
RUN curl -fsSL https://get.dune.build/install | sh
ENV PATH="/root/.dune/bin:$PATH"
WORKDIR /root
RUN git clone https://github.com/mefyl/timmy
RUN git config --global --add safe.directory /root/.cache/dune/git-repo
WORKDIR /root/timmy
RUN dune pkg lock
RUN dune build
```
Line 7 is necessary as the line 3 executes the script as root, thus the permissions of the repo are wrong. It can either be fixed by telling `git` not to worry about it or by `chown -R root /root/.cache/dune/git-repo` but both are workarounds.

This PR should fix the issue by passing the right options to `tar` (if supported).