### PR TITLE
Add line breaks to code blocks

### DIFF
--- a/lib/web.mlx
+++ b/lib/web.mlx
@@ -13,7 +13,12 @@ module Code = struct
   let make ~children () =
       <pre class_="w-full bg-section-code px-5 rounded-md">
         <code class_="w-full h-full py-4 ">
-        (List.map (fun child -> (<span>child</span>)) children |> JSX.list)
+        (List.map (fun child -> (
+            (* Note that the <br/> below is necessary as otherwise the
+               codeblock will lack line breaks and copy/pasting it will remove
+               all newlines. *)
+            <span>child<br/></span>
+        )) children |> JSX.list)
         </code>
       </pre>
 end


### PR DESCRIPTION
Mlx seems to emit all html on a single line, include inside `<pre>` tags. Thus the apparent line breaks in code blocks cannot be copy/pasted, and copy/pasting results in all the code on a single line. This change adds explicit html line breaks at the end of each line of code to work around this issue.