### PR TITLE
Fix tailwindcss url

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,6 +56,6 @@
 
 (pin
  (url
-  "git+https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz")
+  "git+https://github.com/tmattio/opam-tailwindcss#e5bb6361a50c7cc5cad802311e609336583ca08f")
  (package
   (name tailwindcss)))


### PR DESCRIPTION
Prior to this change one gets the following error when locking the project:

```
remote: Not Found
fatal: repository 'https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz/' not found
File "dune-project", line 59, characters 2-107:
59 |   "git+https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz")
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Failed to run external command:
'git ls-remote "https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz"'
Hint: Check that this Git URL in the project configuration is correct:
"https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz"
```