### PR TITLE
Use more restrictive options to make `curl` safer

### DIFF
--- a/static/install
+++ b/static/install
@@ -111,8 +111,10 @@ if [ ! -d "$bin_dir" ]; then
         error "Failed to create install directory \"$bin_dir\""
 fi
 
-curl --fail --location --progress-bar --output "$tmp_tar" "$dune_tar_uri" ||
-    error "Failed to download dune tar from \"$dune_tar_uri\""
+curl --fail --location --progress-bar \
+    --proto '=https' --tlsv1.2 \
+    --output "$tmp_tar" "$dune_tar_uri" ||
+        error "Failed to download dune tar from \"$dune_tar_uri\""
 
 
 tar -xf "$tmp_tar" -C "$tmp_dir" "${tar_owner}" > /dev/null 2>&1 ||
@@ -185,6 +187,7 @@ if [ ! -d "${rev_store_dir}" ] ; then
     fi
 
     curl --fail --location --progress-bar \
+        --proto '=https' --tlsv1.2 \
         --output "${opam_repo_filename}" \
         "${opam_repo_tarball}" ||
 	    error "Failed to download opam-repository snapshot from \"$opam_repo_tarball}\""


### PR DESCRIPTION
Inspired by @smorimoto's #126 I think these options make sense to add in the script:

  * `--tlsv1.2` will require TLS 1.2+ (but also allow 1.3) thus prevents it from using older, less secure TLS versions
  * `--proto '=https'` will prevent redirecting to HTTP. Since we download from GitHub and where GitHub redirects to is outside of our control I think there is a point in making sure it will fail if it redirects to a HTTP location.

Both our server and Github support TLSv1.2, the question is more whether our users have `curl` that support these options. My `curl` has them and the one in Alpine as well, so maybe this is fine without a feature check?

WDYT?