### PR TITLE
feat: make the getting started clearer

### DIFF
--- a/lib/web.mlx
+++ b/lib/web.mlx
@@ -189,10 +189,11 @@ let getting_started ~install_url () =
       "Run"
     </h4>
     <Code>
-"$ dune init proj hello_world"
-"$ cd hello_world"
+"$ PROJECT=hello_world"
+"$ dune init proj \"$PROJECT\""
+"$ cd \"$PROJECT\""
 "$ dune pkg lock"
-"$ dune exec hello_world"
+"$ dune exec \"$PROJECT\""
     </Code>
     <h3 class_="mt-10 mb-2.5">"Editor Configuration"</h3>
     <p>


### PR DESCRIPTION
As suggested in #106, it can be confusing for the user to create a new project. The proposed solution makes it clearer what happens when using `dune init` when you create a project (the name and how to invoke it).

This is more for people who are not used to `dune`, but I would expect advanced `dune` users to skip this part when downloading the Dune Developer Preview.
