### PR TITLE
fix: stop uploading executables

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -105,7 +105,6 @@ jobs:
           cp -r $GITHUB_WORKSPACE/dune-binary-distribution/env ~/build/$ARCHIVE_DIR
           cp -r $GITHUB_WORKSPACE/dune-binary-distribution/completions ~/build/$ARCHIVE_DIR
           cp -r $GITHUB_WORKSPACE/dune-binary-distribution/tool-wrappers ~/build/$ARCHIVE_DIR
-          cp result/bin/dune ~/build/
           tar --format=posix -cvf ~/build/$ARCHIVE_TAR -C ~/build $ARCHIVE_DIR
           gzip -9 ~/build/$ARCHIVE_TAR
           rm -rf ~/build/$ARCHIVE_DIR


### PR DESCRIPTION
In the past, we have been uploading executable to https://get.dune.build. When we moved to a TAR version of the scripts, I kept the executable uploaded to make sure people with the old script would get the correct version.

Now we don't serve the old script any more and there is no more link to the executables (as we only display the 30 months version), we can confidently remove the copy of the script to the static server.

Fixes #47 