### PR TITLE
Install to `.local` instead of `.dune`

### DIFF
--- a/env/env.bash
+++ b/env/env.bash
@@ -1,3 +1,15 @@
 #!/usr/bin/env bash
-export PATH="$HOME/.dune/bin:$PATH"
-source "$HOME/.dune/completions/bash.sh"
+
+# add path if not already done, inspired by rustup
+# affix colons on either side of $PATH to simplify matching
+case ":${PATH}:" in
+    *:"$HOME/.local/bin":*)
+        ;;
+    *)
+        # Prepending path in case a system-installed dune needs to be overridden
+        export PATH="$HOME/.local/bin:$PATH"
+        ;;
+esac
+
+# completions
+source "$HOME/.local/share/dune/completions/bash.sh"

--- a/env/env.fish
+++ b/env/env.fish
@@ -1,2 +1,2 @@
 #!/usr/bin/env fish
-set --export PATH $HOME/.dune/bin $PATH
+fish_add_path --prepend --path $HOME/.loca/bin

--- a/env/env.zsh
+++ b/env/env.zsh
@@ -1,6 +1,18 @@
 #!/usr/bin/env zsh
-export PATH="$HOME/.dune/bin:$PATH"
+
+# add path if not already done, inspired by rustup
+# affix colons on either side of $PATH to simplify matching
+case ":${PATH}:" in
+    *:"$HOME/.local/bin":*)
+        ;;
+    *)
+        # Prepending path in case a system-installed dune needs to be overridden
+        export PATH="$HOME/.local/bin:$PATH"
+        ;;
+esac
+
+# completions via bash compat
 autoload -Uz compinit bashcompinit
 compinit
 bashcompinit
-source "$HOME/.dune/completions/bash.sh"
+source "$HOME/.local/share/dune/completions/bash.sh"

--- a/lib/web.mlx
+++ b/lib/web.mlx
@@ -249,8 +249,8 @@ let getting_started ~install_url () =
             <Code>
 "; init.el"
 "; add the dune developer preview bin path to exec-path and PATH"
-"(add-to-list 'exec-path \"~/.dune/bin\" t)"
-"(setenv \"PATH\" (concat (expand-file-name \"~/.dune/bin\") \":\" (getenv \"PATH\")))"
+"(add-to-list 'exec-path \"~/.local/bin\" t)"
+"(setenv \"PATH\" (concat (expand-file-name \"~/.local/bin\") \":\" (getenv \"PATH\")))"
 " "
 "; mode for editing ocaml files"
 "(use-package tuareg)"
@@ -407,10 +407,8 @@ let manual_installation ~base_url ~releases () =
       "Run"
     </h4>
     <Code>
-"$ tar xzvf dune-<arch>.tar.gz"
-"dune-<arch>"
-"$ cd dune-<arch>"
-"$ sudo mv \"./dune\" \"$HOME/.local/bin/dune\""
+"$ tar xzf dune-<arch>.tar.gz"
+"$ mv dune-<arch>/dune ~/.local/bin/"
     </Code>
     <p class_="mt-2.5 mb-2.5">"You can verify your installation by running:"</p>
     <Code>

--- a/static/install
+++ b/static/install
@@ -80,8 +80,11 @@ tar_target_name="dune-$target"
 tar_target="$tar_target_name.tar.gz"
 dune_tar_uri="https://preview.dune.build/latest/$target"
 
-install_dir="$HOME/.dune"
-bin_dir="$install_dir/bin"
+install_dir="$HOME/.local"
+bin_dir="${install_dir}/bin"
+share_dir="${install_dir}/share/dune"
+completions_dir="${share_dir}/completions"
+env_dir="${share_dir}/env"
 
 tmp_dir="$(mktemp -d -t dune-install.XXXXXXXXXX)"
 if [ ! $? ]; then
@@ -128,20 +131,23 @@ tmp_exe="$tmp_tar_dir/dune"
 mv "$tmp_exe" "$exe" ||
     error "Failed to move executable from $tmp_exe to $exe"
 
-if [ -d "$install_dir/env" ]; then
-    rm -r "$install_dir/env"
-fi
-mv "$tmp_tar_dir/env" "$install_dir" ||
-    error "Failed to move env from $tmp_tar_dir to $install_dir"
+mkdir -p "${share_dir}"
 
-if [ -d "$install_dir/completions" ]; then
-    rm -r "$install_dir/completions"
+if [ -d "${env_dir}" ]; then
+    rm -r "${env_dir}"
 fi
-mv "$tmp_tar_dir/completions" "$install_dir" ||
-    error "Failed to move completions from $tmp_tar_dir to $install_dir"
+
+mv "$tmp_tar_dir/env" "${share_dir}" ||
+    error "Failed to move env from \"$tmp_tar_dir\" to \"$share_dir\""
+
+if [ -d "${completions_dir}" ]; then
+    rm -r "${completions_dir}"
+fi
+mv "$tmp_tar_dir/completions" "${share_dir}" ||
+    error "Failed to move completions from \"$tmp_tar_dir\" to \"$share_dir\""
 
 mv "$tmp_tar_dir"/tool-wrappers/* "$bin_dir" ||
-    error "Failed to move tool wrapper scripts from $tmp_tar_dir to $install_dir"
+    error "Failed to move tool wrapper scripts from \"$tmp_tar_dir\" to \"$bin_dir\""
 
 success "dune $target was installed successfully to"
 success_bold "$(tildify "$exe")"
@@ -205,15 +211,24 @@ fi
 
 already_installed=false
 
-case $(basename "$SHELL") in
+unsubst_home() {
+    echo "$1" | sed -e "s#^$HOME#\$HOME#"
+}
+
+remove_home() {
+    echo "$1" | sed -e "s#^$HOME/##" | sed -e 's#^/##'
+}
+
+case $(basename "${SHELL:-*}") in
 fish)
-    env_file="\$HOME/.dune/env/env.fish"
+    env="${env_dir}/env.fish"
+    env_file=$(unsubst_home "${env}")
 
     fish_config=$HOME/.config/fish/config.fish
     tilde_fish_config=$(tildify "$fish_config")
 
     # deliberately omit the home directory from the pattern so "~" and "$HOME" can be used interchangeably
-    if [ -f "$fish_config" ] && match=$(grep -n ".dune/env/env.fish" "$fish_config"); then
+    if [ -f "$fish_config" ] && match=$(grep -n "$(remove_home "${env}")" "$fish_config"); then
         echo "Shell configuration for dune appears to already exist in \"$fish_config\":"
         echo "$match"
         already_installed=true
@@ -230,15 +245,16 @@ fish)
         echo
     fi
     ;;
-zsh)
 
-    env_file="\$HOME/.dune/env/env.zsh"
+zsh)
+    env="${env_dir}/env.zsh"
+    env_file=$(unsubst_home "${env}")
 
     zsh_config=$HOME/.zshrc
     tilde_zsh_config=$(tildify "$zsh_config")
 
     # deliberately omit the home directory from the pattern so "~" and "$HOME" can be used interchangeably
-    if [ -f "$zsh_config" ] && match=$(grep -n ".dune/env/env.zsh" "$zsh_config"); then
+    if [ -f "$zsh_config" ] && match=$(grep -n "$(remove_home "${env}")" "$zsh_config"); then
         echo "Shell configuration for dune appears to already exist in \"$zsh_config\":"
         echo "$match"
         already_installed=true
@@ -255,9 +271,10 @@ zsh)
         echo
     fi
     ;;
-bash)
 
-    env_file="\$HOME/.dune/env/env.bash"
+bash)
+    env="${env_dir}/env.bash"
+    env_file=$(unsubst_home "${env}")
 
     bash_configs="$HOME/.bashrc $HOME/.bash_profile"
 
@@ -267,7 +284,7 @@ bash)
 
     for bash_config in $bash_configs; do
         # deliberately omit the home directory from the pattern so "~" and "$HOME" can be used interchangeably
-        if [ -f "$bash_config" ] && match=$(grep -n ".dune/env/env.bash" "$bash_config"); then
+	if [ -f "$bash_config" ] && match=$(grep -n "$(remove_home "${env}")" "$bash_config"); then
             echo "Shell configuration for dune appears to already exist in \"$bash_config\":"
             echo "$match"
             refresh_command="source $bash_config"
@@ -299,8 +316,11 @@ bash)
         fi
     fi
     ;;
-*)
-    env_file="\$HOME/.dune/env/env.bash"
+
+*|unset)
+    env="${env_dir}/env.bash"
+    env_file=$(unsubst_home "${env}")
+
     echo "To use dune you will need to source the file \"$env_file\" (or similar as appropriate for your shell)"
     info_bold "  export PATH=\"$bin_dir:\$PATH\""
     echo


### PR DESCRIPTION
This changes the location into which Dune is installed into the users `.local` folder, which is fairly standard for a lot of user-installed packages.

It also changes the locations for env & completions to fit with the conventions and reworks the config editing to compute the paths. I got them all wrong all the time, missing one or the other component so now the computer does all the computing for me.

Finally it adds a fallback for when SHELL isn't set. Dash doesn't set SHELL so it prints an error (and continues with the `*` branch anyway). This makes avoids the error message while still executing the same fallback branch.

There's two reasons for this change:

  * `.local` is a fairly standard convention and people might actually have `~/.local/bin` in their paths
  * `.dune` conflicts with `dune-release` which will, upon the presence of `.dune` attempt to migrate it's config file to `~/.config` (which is, overall, a good thing) and fail. While this is a bug in `dune-release`, it shows one of the problems of using dotfiles directly in the user directory.