### PR TITLE
Use page view script

### DIFF
--- a/lib/container.mlx
+++ b/lib/container.mlx
@@ -83,7 +83,7 @@ let page ~title content =
       <link rel="shortcut icon" href="/static/dune_favicon.png" />
       <script
         dataDomain="preview.dune.build" defer=true
-        src="https://plausible.ci.dev/js/script.file-downloads.js"></script>
+        src="https://plausible.ci.dev/js/script.js"></script>
     </head>
     <body class_="min-h-dvh w-full flex flex-col overflow-scroll justify-between items-center">
       <navbar />


### PR DESCRIPTION
Use the default `/js/script.js` rather than the `/js/file-downloads.js`.

Downloads are now tracked by parsing the Caddy log files and pushing those events to Plausible.  Leaving this unchanged will double-count some downloads.