### PR TITLE
feat: build sandworm with dune pkg management

### DIFF
--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -96,7 +96,6 @@ jobs:
           subject-path: "result/bin/dune"
           show-summary: false
 
-      # TODO: remove the extra Dune file when the complete move to tar is done.
       - name: Extract artifact and attestation
         run: |
           mkdir -p ~/build/$ARCHIVE_DIR/

--- a/.github/workflows/binary.yaml
+++ b/.github/workflows/binary.yaml
@@ -165,6 +165,10 @@ jobs:
         run: |
           sudo -v ; curl https://rclone.org/install.sh | sudo bash
 
+      - name: Install sandworm external deps
+        run: |
+          sudo apt-get install $(dune show depexts) libev-dev
+
       - name: Prepare SSH env
         shell: bash
         run: |
@@ -179,14 +183,28 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_PUBLIC_KEY: ${{ secrets.SSH_PUBLIC_KEY }}
 
+      - name: Set up date environment variables
+        run: echo "DATE=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
+
+      - name: Set binary environment variables
+        run: |
+          echo "ARCHIVE_TARGZ=dune-$DATE-x86_64-unknown-linux-musl.tar.gz" >> $GITHUB_ENV
+          echo "ARCHIVE_DIR=dune-$DATE-x86_64-unknown-linux-musl" >> $GITHUB_ENV
+
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup OCaml with cache
-        uses: ocaml/setup-ocaml@v3
+      - uses: actions/download-artifact@v4
         with:
-          ocaml-compiler: "5.2"
-          dune-cache: true
+          path: /home/runner/artifacts
+
+      - name: Get dune accessible
+        run: |
+          cp "/home/runner/artifacts/x86_64-unknown-linux-musl/$ARCHIVE_TARGZ" .
+          tar -xvf "$ARCHIVE_TARGZ"
+          mkdir -p "$HOME/.local/bin"
+          mv "./$ARCHIVE_DIR/dune" "$HOME/.local/bin"
+          rm -rf "./$ARCHIVE_DIR"
 
       - name: Update config on test
         if: ${{ github.ref == 'refs/heads/staging' }}
@@ -197,11 +215,7 @@ jobs:
           cat ./bin/config.ml
 
       - name: Install Sandworm deps && build
-        run: opam install -y . --deps-only && opam exec -- dune build
-
-      - uses: actions/download-artifact@v4
-        with:
-          path: /home/runner/artifacts
+        run: dune build
 
       - name: Move artifacts to scope
         run: mv "/home/runner/artifacts" "."
@@ -211,7 +225,7 @@ jobs:
 
       - name: Export executables and generate html
         shell: bash
-        run: opam exec -- dune exec sandworm -- sync --commit "${{ needs.binary.outputs.git-commit }}"
+        run: ./_build/install/default/bin/sandworm sync --commit "${{ needs.binary.outputs.git-commit }}"
 
       - name: Commit changes to branch
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@ _build/
 
 # Local OPAM switch
 _opam/
-dune.lock
 dev-tools.locks

--- a/dune.lock/angstrom.pkg
+++ b/dune.lock/angstrom.pkg
@@ -1,0 +1,15 @@
+(version 0.16.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune bigstringaf ocaml-syntax-shims)
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/angstrom/archive/0.16.1.tar.gz)
+  (checksum md5=a9e096b4b2b8e4e3bb17d472bbccaad0)))

--- a/dune.lock/asn1-combinators.pkg
+++ b/dune.lock/asn1-combinators.pkg
@@ -1,0 +1,17 @@
+(version 0.3.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune ptime)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirleft/ocaml-asn1-combinators/releases/download/v0.3.2/asn1-combinators-0.3.2.tbz)
+  (checksum
+   sha256=2b26985f6e2722073dcd9f84355bd6757e12643b5a48e30b3c07ff7cfb0d8a7f)))

--- a/dune.lock/astring.pkg
+++ b/dune.lock/astring.pkg
@@ -1,0 +1,12 @@
+(version 0.8.5)
+
+(build
+ (run ocaml pkg/pkg.ml build --pinned %{pkg-self:pinned}))
+
+(depends ocaml ocamlfind ocamlbuild topkg)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/astring/releases/astring-0.8.5.tbz)
+  (checksum
+   sha256=865692630c07c3ab87c66cdfc2734c0fdfc9c34a57f8e89ffec7c7d15e7a70fa)))

--- a/dune.lock/base-bytes.pkg
+++ b/dune.lock/base-bytes.pkg
@@ -1,0 +1,3 @@
+(version base)
+
+(depends ocaml ocamlfind)

--- a/dune.lock/base-threads.pkg
+++ b/dune.lock/base-threads.pkg
@@ -1,0 +1,1 @@
+(version base)

--- a/dune.lock/base-unix.pkg
+++ b/dune.lock/base-unix.pkg
@@ -1,0 +1,1 @@
+(version base)

--- a/dune.lock/base64.pkg
+++ b/dune.lock/base64.pkg
@@ -1,0 +1,17 @@
+(version 3.5.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-base64/releases/download/v3.5.1/base64-3.5.1.tbz)
+  (checksum
+   sha256=d8fedaa59bd12feae7acc08b5928dd478aac523f4ca8d240470d2500651c65ed)))

--- a/dune.lock/bigarray-compat.pkg
+++ b/dune.lock/bigarray-compat.pkg
@@ -1,0 +1,17 @@
+(version 1.1.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/bigarray-compat/releases/download/v1.1.0/bigarray-compat-1.1.0.tbz)
+  (checksum
+   sha256=434469a48d5c84e80d621b13d95eb067f8138c1650a1fd5ae6009a19b93718d5)))

--- a/dune.lock/bigarray-overlap.pkg
+++ b/dune.lock/bigarray-overlap.pkg
@@ -1,0 +1,13 @@
+(version 0.2.1)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune conf-pkg-config)
+
+(source
+ (fetch
+  (url
+   https://github.com/dinosaure/overlap/releases/download/v0.2.1/bigarray-overlap-0.2.1.tbz)
+  (checksum
+   sha256=2f520ac470054e335883eba9254bf28b6676ddb57753cfb58b22cf84ae1a66e0)))

--- a/dune.lock/bigstringaf.pkg
+++ b/dune.lock/bigstringaf.pkg
@@ -1,0 +1,15 @@
+(version 0.10.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune dune-configurator ocaml)
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/bigstringaf/archive/0.10.0.tar.gz)
+  (checksum md5=be0a44416840852777651150757a0a3b)))

--- a/dune.lock/camlp-streams.pkg
+++ b/dune.lock/camlp-streams.pkg
@@ -1,0 +1,15 @@
+(version 5.0.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml)
+
+(source
+ (fetch
+  (url https://github.com/ocaml/camlp-streams/archive/v5.0.1.tar.gz)
+  (checksum md5=afc874b25f7a1f13e8f5cfc1182b51a7)))

--- a/dune.lock/caqti-lwt.pkg
+++ b/dune.lock/caqti-lwt.pkg
@@ -1,0 +1,13 @@
+(version 2.1.1)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends caqti dune domain-name ipaddr logs mtime lwt ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.1/caqti-v2.1.1.tbz)
+  (checksum
+   sha256=483a535f41e2641917fc1832ce4ad15ffc3f4e8283b1b3018a2617349583090a)))

--- a/dune.lock/caqti.pkg
+++ b/dune.lock/caqti.pkg
@@ -1,0 +1,35 @@
+(version 2.1.2)
+
+(build
+ (progn
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)
+  (run
+   dune
+   install
+   -p
+   %{pkg-self:name}
+   --create-install-file
+   %{pkg-self:name})))
+
+(depends
+ angstrom
+ bigstringaf
+ domain-name
+ dune
+ dune-site
+ ipaddr
+ logs
+ lwt-dllist
+ mtime
+ ocaml
+ ptime
+ tls
+ uri
+ x509)
+
+(source
+ (fetch
+  (url
+   https://github.com/paurkedal/ocaml-caqti/releases/download/v2.1.2/caqti-v2.1.2.tbz)
+  (checksum
+   sha256=ba4dfd5ff94376b5e003f682410b7b3b392c0bbaa0253679fe7671c2e07e895b)))

--- a/dune.lock/checkseum.pkg
+++ b/dune.lock/checkseum.pkg
@@ -1,0 +1,13 @@
+(version 0.5.2)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune dune-configurator optint)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/checkseum/releases/download/v0.5.2/checkseum-0.5.2.tbz)
+  (checksum
+   sha256=9e5e4fd4405cb4a8b4df00877543251833e08a6499ef42ccb8dba582df0dafc8)))

--- a/dune.lock/cmdliner.pkg
+++ b/dune.lock/cmdliner.pkg
@@ -1,0 +1,17 @@
+(version 1.3.0)
+
+(install
+ (progn
+  (run %{make} install LIBDIR=%{pkg-self:lib} DOCDIR=%{pkg-self:doc})
+  (run %{make} install-doc LIBDIR=%{pkg-self:lib} DOCDIR=%{pkg-self:doc})))
+
+(build
+ (run %{make} all PREFIX=%{prefix}))
+
+(depends ocaml)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/cmdliner/releases/cmdliner-1.3.0.tbz)
+  (checksum
+   sha512=4c46bc334444ff772637deae2f5ba03645d7a1b7db523470a1246acfce79b971c764d964cbb02388639b3161b279700d9ade95da550446fb32aa4849c8a8f283)))

--- a/dune.lock/conf-gmp-powm-sec.pkg
+++ b/dune.lock/conf-gmp-powm-sec.pkg
@@ -1,0 +1,14 @@
+(version 3)
+
+(build
+ (run sh -exc "cc -c $CFLAGS -I/usr/local/include test.c"))
+
+(depends conf-gmp)
+
+(extra_sources
+ (test.c
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp-powm-sec/test.c.3)
+   (checksum
+    sha256=388b3879530257a7e6e59b68208ee2a52de7be30e40eb4d3a54419708fdad490))))

--- a/dune.lock/conf-gmp.pkg
+++ b/dune.lock/conf-gmp.pkg
@@ -1,0 +1,12 @@
+(version 4)
+
+(build
+ (run sh -exc "cc -c $CFLAGS -I/usr/local/include test.c"))
+
+(extra_sources
+ (test.c
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-gmp/test.c.4)
+   (checksum
+    sha256=54a30735f1f271a2531526747e75716f4490dd7bc1546efd6498ccfe3cc4d6fb))))

--- a/dune.lock/conf-libev.pkg
+++ b/dune.lock/conf-libev.pkg
@@ -1,0 +1,22 @@
+(version 4-12)
+
+(build
+ (run sh ./build.sh))
+
+(depends ocaml)
+
+(depexts libev)
+
+(extra_sources
+ (build.sh
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-libev/build.sh)
+   (checksum
+    sha256=4825462f8f84312caf9a2c797bbd24abc776d8a343de5561330314d846e5cf61)))
+ (discover.ml
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-libev/discover.ml.4-12)
+   (checksum
+    sha256=1db79a9fa1c8642c9466d129a0077199b1e2ed4663e3659545ba8a9e287f8742))))

--- a/dune.lock/conf-libssl.pkg
+++ b/dune.lock/conf-libssl.pkg
@@ -1,0 +1,18 @@
+(version 4)
+
+(build
+ (withenv
+  ((= HOMEBREW_NO_AUTO_UPDATE 1))
+  (run pkg-config --print-errors --exists openssl)))
+
+(depends conf-pkg-config)
+
+(depexts openssl)
+
+(extra_sources
+ (homebrew.sh
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/conf-libssl/homebrew.sh.4)
+   (checksum
+    sha256=c6e132e784f0d3250b434a91ad806416ad6c30e25465bd4e37df946a33bfbad2))))

--- a/dune.lock/conf-pkg-config.pkg
+++ b/dune.lock/conf-pkg-config.pkg
@@ -1,0 +1,6 @@
+(version 4)
+
+(build
+ (run pkg-config --help))
+
+(depexts pkgconf)

--- a/dune.lock/conf-sqlite3.pkg
+++ b/dune.lock/conf-sqlite3.pkg
@@ -1,0 +1,6 @@
+(version 1)
+
+(build
+ (run pkg-config sqlite3))
+
+(depends conf-pkg-config)

--- a/dune.lock/cppo.pkg
+++ b/dune.lock/cppo.pkg
@@ -1,0 +1,15 @@
+(version 1.8.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends ocaml dune base-unix)
+
+(source
+ (fetch
+  (url https://github.com/ocaml-community/cppo/archive/v1.8.0.tar.gz)
+  (checksum md5=a197cb393b84f6b30e0ff55080ac429b)))

--- a/dune.lock/csexp.pkg
+++ b/dune.lock/csexp.pkg
@@ -1,0 +1,17 @@
+(version 1.5.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-dune/csexp/releases/download/1.5.2/csexp-1.5.2.tbz)
+  (checksum
+   sha256=1a14dd04bb4379a41990248550628c77913a9c07f3c35c1370b6960e697787ff)))

--- a/dune.lock/cstruct.pkg
+++ b/dune.lock/cstruct.pkg
@@ -1,0 +1,17 @@
+(version 6.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune fmt)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-cstruct/releases/download/v6.2.0/cstruct-6.2.0.tbz)
+  (checksum
+   sha256=9a78073392580e8349148fa3ab4b1b2e989dc9d30d07401b04c96b7c60f03e62)))

--- a/dune.lock/decompress.pkg
+++ b/dune.lock/decompress.pkg
@@ -1,0 +1,13 @@
+(version 1.5.3)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune cmdliner optint checkseum)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/decompress/releases/download/v1.5.3/decompress-1.5.3.tbz)
+  (checksum
+   sha256=f91e6978beff3fcb61440d32f7c99c99f1e8654b4fb18408741d36035373ac60)))

--- a/dune.lock/digestif.pkg
+++ b/dune.lock/digestif.pkg
@@ -1,0 +1,13 @@
+(version 1.2.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune eqaf)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/digestif/releases/download/v1.2.0/digestif-1.2.0.tbz)
+  (checksum
+   sha256=c30168cafe279a665367806b3e5e6398fd7474f1e5260e76826d5ec9d3b2a508)))

--- a/dune.lock/domain-name.pkg
+++ b/dune.lock/domain-name.pkg
@@ -1,0 +1,17 @@
+(version 0.4.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/hannesm/domain-name/releases/download/v0.4.1/domain-name-0.4.1.tbz)
+  (checksum
+   sha256=1dba32f35a7cd5cc8187d21e2cc21a0b667a645447a0eefe57afe3ca25bc4566)))

--- a/dune.lock/dream-encoding.pkg
+++ b/dune.lock/dream-encoding.pkg
@@ -1,0 +1,17 @@
+(version 0.3.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml dream decompress lwt_ppx)
+
+(source
+ (fetch
+  (url
+   https://github.com/tmattio/dream-encoding/releases/download/0.3.0/dream-encoding-0.3.0.tbz)
+  (checksum
+   sha256=5778442d5d1e2cede3657151242fd2aac12176546fb76fc4d0a5181bd32605ef)))

--- a/dune.lock/dream-httpaf.pkg
+++ b/dune.lock/dream-httpaf.pkg
@@ -1,0 +1,27 @@
+(version 1.0.0~alpha4)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends
+ dream-pure
+ dune
+ gluten
+ gluten-lwt-unix
+ h2
+ h2-lwt-unix
+ httpun
+ httpun-lwt-unix
+ httpun-ws
+ lwt
+ lwt_ppx
+ lwt_ssl
+ ocaml
+ ssl)
+
+(source
+ (fetch
+  (url
+   https://github.com/aantron/dream/releases/download/1.0.0-alpha8/dream-1.0.0-alpha8.tar.gz)
+  (checksum
+   sha256=23ed812890c03fe5c9974a4961a9e8e62126bed7bc7d7d1440b84652c95cf296)))

--- a/dune.lock/dream-pure.pkg
+++ b/dune.lock/dream-pure.pkg
@@ -1,0 +1,13 @@
+(version 1.0.0~alpha2)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends base64 bigstringaf dune hmap lwt lwt_ppx ocaml ptime uri)
+
+(source
+ (fetch
+  (url
+   https://github.com/aantron/dream/releases/download/1.0.0-alpha4/dream-1.0.0-alpha4.tar.gz)
+  (checksum
+   sha256=a143b3694d67c0089ea16ce4585971d6333f05001abcadcede6696b06ca6af10)))

--- a/dune.lock/dream.pkg
+++ b/dune.lock/dream.pkg
@@ -1,0 +1,45 @@
+(version 1.0.0~alpha8)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends
+ base-unix
+ bigarray-compat
+ camlp-streams
+ caqti
+ caqti-lwt
+ conf-libev
+ cstruct
+ digestif
+ dream-httpaf
+ dream-pure
+ dune
+ fmt
+ graphql_parser
+ graphql-lwt
+ lambdasoup
+ lwt
+ lwt_ppx
+ lwt_ssl
+ logs
+ magic-mime
+ markup
+ mirage-clock
+ mirage-crypto
+ mirage-crypto-rng
+ mirage-crypto-rng-lwt
+ multipart_form
+ multipart_form-lwt
+ ocaml
+ ptime
+ ssl
+ uri
+ yojson)
+
+(source
+ (fetch
+  (url
+   https://github.com/aantron/dream/releases/download/1.0.0-alpha8/dream-1.0.0-alpha8.tar.gz)
+  (checksum
+   sha256=23ed812890c03fe5c9974a4961a9e8e62126bed7bc7d7d1440b84652c95cf296)))

--- a/dune.lock/dune-configurator.pkg
+++ b/dune.lock/dune-configurator.pkg
@@ -1,0 +1,19 @@
+(version 3.17.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run rm -rf vendor/csexp)
+  (run rm -rf vendor/pp)
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml base-unix csexp)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
+  (checksum
+   sha256=9deafeed0ecfe9e65e642cd8e6197f0864f73fcd7b94b5b199ae4d2e07a2ea64)))

--- a/dune.lock/dune-private-libs.pkg
+++ b/dune.lock/dune-private-libs.pkg
@@ -1,0 +1,19 @@
+(version 3.17.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run rm -rf vendor/csexp)
+  (run rm -rf vendor/pp)
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune csexp pp dyn stdune ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
+  (checksum
+   sha256=9deafeed0ecfe9e65e642cd8e6197f0864f73fcd7b94b5b199ae4d2e07a2ea64)))

--- a/dune.lock/dune-site.pkg
+++ b/dune.lock/dune-site.pkg
@@ -1,0 +1,19 @@
+(version 3.17.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run rm -rf vendor/csexp)
+  (run rm -rf vendor/pp)
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune dune-private-libs)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
+  (checksum
+   sha256=9deafeed0ecfe9e65e642cd8e6197f0864f73fcd7b94b5b199ae4d2e07a2ea64)))

--- a/dune.lock/duration.pkg
+++ b/dune.lock/duration.pkg
@@ -1,0 +1,17 @@
+(version 0.2.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/hannesm/duration/releases/download/v0.2.1/duration-0.2.1.tbz)
+  (checksum
+   sha256=c738c1f38cfb99820c121cd3ddf819de4b2228f0d50eacbd1cc3ce99e7c71e2b)))

--- a/dune.lock/dyn.pkg
+++ b/dune.lock/dyn.pkg
@@ -1,0 +1,19 @@
+(version 3.17.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run rm -rf vendor/csexp)
+  (run rm -rf vendor/pp)
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml ordering pp)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
+  (checksum
+   sha256=9deafeed0ecfe9e65e642cd8e6197f0864f73fcd7b94b5b199ae4d2e07a2ea64)))

--- a/dune.lock/eqaf.pkg
+++ b/dune.lock/eqaf.pkg
@@ -1,0 +1,16 @@
+(version 0.10)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url https://github.com/mirage/eqaf/releases/download/v0.10/eqaf-0.10.tbz)
+  (checksum
+   sha256=67d1369c57c4d2d14a10d02632d45e355224abeb98aec08979c0bae5843092ee)))

--- a/dune.lock/faraday-lwt-unix.pkg
+++ b/dune.lock/faraday-lwt-unix.pkg
@@ -1,0 +1,16 @@
+(version 0.8.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune faraday-lwt lwt base-unix)
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/faraday/archive/0.8.2.tar.gz)
+  (checksum
+   sha256=720ea90b39fd3ea7de6e8722330a25514e67306e94d4af41ad48d8a7cfa035c6)))

--- a/dune.lock/faraday-lwt.pkg
+++ b/dune.lock/faraday-lwt.pkg
@@ -1,0 +1,16 @@
+(version 0.8.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune faraday lwt)
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/faraday/archive/0.8.2.tar.gz)
+  (checksum
+   sha256=720ea90b39fd3ea7de6e8722330a25514e67306e94d4af41ad48d8a7cfa035c6)))

--- a/dune.lock/faraday.pkg
+++ b/dune.lock/faraday.pkg
@@ -1,0 +1,16 @@
+(version 0.8.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune bigstringaf)
+
+(source
+ (fetch
+  (url https://github.com/inhabitedtype/faraday/archive/0.8.2.tar.gz)
+  (checksum
+   sha256=720ea90b39fd3ea7de6e8722330a25514e67306e94d4af41ad48d8a7cfa035c6)))

--- a/dune.lock/fmt.pkg
+++ b/dune.lock/fmt.pkg
@@ -1,0 +1,21 @@
+(version 0.10.0)
+
+(build
+ (run
+  ocaml
+  pkg/pkg.ml
+  build
+  --dev-pkg
+  %{pkg-self:dev}
+  --with-base-unix
+  %{pkg:base-unix:installed}
+  --with-cmdliner
+  %{pkg:cmdliner:installed}))
+
+(depends ocaml ocamlfind ocamlbuild topkg base-unix cmdliner)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/fmt/releases/fmt-0.10.0.tbz)
+  (checksum
+   sha512=26d7f2002f0f1d605c08129ec09d487a8c37d764b77370e56b869fd94fe6bc903f808159ab7b79e85c2e2b6263ee5fa7df66f9f9625bdf0e726e8a92a9056258)))

--- a/dune.lock/fpath.pkg
+++ b/dune.lock/fpath.pkg
@@ -1,0 +1,18 @@
+(version 0.7.3)
+
+(build
+ (run
+  ocaml
+  pkg/pkg.ml
+  build
+  (when
+   (catch_undefined_var %{pkg-self:dev} false)
+   --dev-pkg=true)))
+
+(depends ocaml ocamlfind ocamlbuild topkg astring)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/fpath/releases/fpath-0.7.3.tbz)
+  (checksum
+   sha256=12b08ff192d037d9b6d69e9ca19d1d385184f20b3237c27231e437ac81ace70f)))

--- a/dune.lock/gluten-lwt-unix.pkg
+++ b/dune.lock/gluten-lwt-unix.pkg
@@ -1,0 +1,17 @@
+(version 0.5.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml gluten-lwt faraday-lwt-unix lwt_ssl)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz)
+  (checksum
+   sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f)))

--- a/dune.lock/gluten-lwt.pkg
+++ b/dune.lock/gluten-lwt.pkg
@@ -1,0 +1,17 @@
+(version 0.5.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml gluten lwt)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz)
+  (checksum
+   sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f)))

--- a/dune.lock/gluten.pkg
+++ b/dune.lock/gluten.pkg
@@ -1,0 +1,17 @@
+(version 0.5.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml bigstringaf faraday)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/gluten/releases/download/0.5.2/gluten-0.5.2.tbz)
+  (checksum
+   sha256=b1eed89f9f6080bb4bd289cc8d252c6bcf01f03d395726e66fa6067207e7015f)))

--- a/dune.lock/gmap.pkg
+++ b/dune.lock/gmap.pkg
@@ -1,0 +1,17 @@
+(version 0.3.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/hannesm/gmap/releases/download/0.3.0/gmap-0.3.0.tbz)
+  (checksum
+   sha256=04dd9e6226ac8f8fb4ccb6021048702e34a482fb9c1d240d3852829529507c1c)))

--- a/dune.lock/graphql-lwt.pkg
+++ b/dune.lock/graphql-lwt.pkg
@@ -1,0 +1,13 @@
+(version 0.14.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune graphql lwt)
+
+(source
+ (fetch
+  (url
+   https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz)
+  (checksum
+   sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06)))

--- a/dune.lock/graphql.pkg
+++ b/dune.lock/graphql.pkg
@@ -1,0 +1,13 @@
+(version 0.14.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune graphql_parser yojson rresult seq)
+
+(source
+ (fetch
+  (url
+   https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz)
+  (checksum
+   sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06)))

--- a/dune.lock/graphql_parser.pkg
+++ b/dune.lock/graphql_parser.pkg
@@ -1,0 +1,13 @@
+(version 0.14.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune menhir fmt re)
+
+(source
+ (fetch
+  (url
+   https://github.com/andreas/ocaml-graphql-server/releases/download/0.14.0/graphql-0.14.0.tbz)
+  (checksum
+   sha256=bf8bf5b9e17e355ecbbd82158a769fe2b138e746753fd3a23008ada3afcd1c06)))

--- a/dune.lock/h2-lwt-unix.pkg
+++ b/dune.lock/h2-lwt-unix.pkg
@@ -1,0 +1,17 @@
+(version 0.12.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml h2-lwt faraday-lwt-unix gluten-lwt-unix lwt_ssl)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz)
+  (checksum
+   sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6)))

--- a/dune.lock/h2-lwt.pkg
+++ b/dune.lock/h2-lwt.pkg
@@ -1,0 +1,17 @@
+(version 0.12.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml h2 lwt gluten-lwt)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz)
+  (checksum
+   sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6)))

--- a/dune.lock/h2.pkg
+++ b/dune.lock/h2.pkg
@@ -1,0 +1,26 @@
+(version 0.12.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends
+ dune
+ ocaml
+ base64
+ angstrom
+ faraday
+ bigstringaf
+ psq
+ hpack
+ httpun-types)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz)
+  (checksum
+   sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6)))

--- a/dune.lock/hmap.pkg
+++ b/dune.lock/hmap.pkg
@@ -1,0 +1,12 @@
+(version 0.8.1)
+
+(build
+ (run ocaml pkg/pkg.ml build --pinned %{pkg-self:pinned}))
+
+(depends ocaml ocamlfind ocamlbuild topkg)
+
+(source
+ (fetch
+  (url http://erratique.ch/software/hmap/releases/hmap-0.8.1.tbz)
+  (checksum
+   sha256=6a00db1b12b6f55e1b2419f206fdfbaa669e14b51c78f8ac3cffa0a58897be83)))

--- a/dune.lock/hpack.pkg
+++ b/dune.lock/hpack.pkg
@@ -1,0 +1,17 @@
+(version 0.12.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml angstrom faraday)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/ocaml-h2/releases/download/0.12.0/h2-0.12.0.tbz)
+  (checksum
+   sha256=36e40b113d90ea383619a8c7bd993f866131c3c5d957619b6849eb32af8c53c6)))

--- a/dune.lock/html_of_jsx.pkg
+++ b/dune.lock/html_of_jsx.pkg
@@ -1,0 +1,17 @@
+(version 0.0.4)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml ppxlib)
+
+(source
+ (fetch
+  (url
+   https://github.com/davesnx/html_of_jsx/releases/download/0.0.4/html_of_jsx-0.0.4.tbz)
+  (checksum
+   sha256=12c49cb44a7476921d097248540e222cb412cf49a283cc20b92775e2bf2b9c39)))

--- a/dune.lock/httpun-lwt-unix.pkg
+++ b/dune.lock/httpun-lwt-unix.pkg
@@ -1,0 +1,13 @@
+(version 0.1.0)
+
+(build
+ (run dune build -p %{pkg-self:name}))
+
+(depends ocaml httpun httpun-lwt dune gluten-lwt-unix)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/httpun/releases/download/0.1.0/httpun-0.1.0.tbz)
+  (checksum
+   sha256=5007465f42e1cf8dec1e019819194b79bc5eed407cb93db4f603304c86a294d1)))

--- a/dune.lock/httpun-lwt.pkg
+++ b/dune.lock/httpun-lwt.pkg
@@ -1,0 +1,13 @@
+(version 0.1.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune httpun lwt gluten-lwt)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/httpun/releases/download/0.1.0/httpun-0.1.0.tbz)
+  (checksum
+   sha256=5007465f42e1cf8dec1e019819194b79bc5eed407cb93db4f603304c86a294d1)))

--- a/dune.lock/httpun-types.pkg
+++ b/dune.lock/httpun-types.pkg
@@ -1,0 +1,13 @@
+(version 0.1.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune faraday)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/httpun/releases/download/0.1.0/httpun-0.1.0.tbz)
+  (checksum
+   sha256=5007465f42e1cf8dec1e019819194b79bc5eed407cb93db4f603304c86a294d1)))

--- a/dune.lock/httpun-ws.pkg
+++ b/dune.lock/httpun-ws.pkg
@@ -1,0 +1,17 @@
+(version 0.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml base64 bigstringaf angstrom faraday gluten httpun)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/httpun-ws/releases/download/0.2.0/httpun-ws-0.2.0.tbz)
+  (checksum
+   sha256=eae0cd2e0eb5b4fc9cb6d862b7116a6f0fc8503b2e439046bf0e6f4cb2c297fd)))

--- a/dune.lock/httpun.pkg
+++ b/dune.lock/httpun.pkg
@@ -1,0 +1,13 @@
+(version 0.1.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune httpun-types bigstringaf angstrom faraday)
+
+(source
+ (fetch
+  (url
+   https://github.com/anmonteiro/httpun/releases/download/0.1.0/httpun-0.1.0.tbz)
+  (checksum
+   sha256=5007465f42e1cf8dec1e019819194b79bc5eed407cb93db4f603304c86a294d1)))

--- a/dune.lock/ipaddr.pkg
+++ b/dune.lock/ipaddr.pkg
@@ -1,0 +1,17 @@
+(version 5.6.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune macaddr domain-name)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/kdf.pkg
+++ b/dune.lock/kdf.pkg
@@ -1,0 +1,17 @@
+(version 1.0.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune digestif mirage-crypto)
+
+(source
+ (fetch
+  (url
+   https://github.com/robur-coop/kdf/releases/download/v1.0.0/kdf-1.0.0.tbz)
+  (checksum
+   sha256=d161582b0efe66d958dd6b8c9c21068e9f6454ce218377d6cf87823dec62e0ce)))

--- a/dune.lock/ke.pkg
+++ b/dune.lock/ke.pkg
@@ -1,0 +1,12 @@
+(version 0.6)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune fmt)
+
+(source
+ (fetch
+  (url https://github.com/mirage/ke/releases/download/v0.6/ke-0.6.tbz)
+  (checksum
+   sha256=61217207e2200b04b17759736610ff9208269a647f854cb5ae72cdac0d672305)))

--- a/dune.lock/lambdasoup.pkg
+++ b/dune.lock/lambdasoup.pkg
@@ -1,0 +1,12 @@
+(version 1.1.1)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends camlp-streams dune markup ocaml)
+
+(source
+ (fetch
+  (url https://github.com/aantron/lambdasoup/archive/1.1.1.tar.gz)
+  (checksum
+   sha256=05d97f38e534a431176ed8d3dbe6dfb7bdcf7770109193c5a69dff53e38f10fe)))

--- a/dune.lock/lock.dune
+++ b/dune.lock/lock.dune
@@ -1,0 +1,32 @@
+(lang package 0.1)
+
+(dependency_hash 407c2f236f8d876b74d95d947a712081)
+
+(ocaml ocaml-base-compiler)
+
+(repositories
+ (complete true)
+ (used
+  ((source
+    https://github.com/ocaml-dune/opam-overlays.git#a538aecc5f1c4a775c41ea156d96bfd173caa43b))
+  ((source
+    https://github.com/ocaml/opam-repository.git#8f63148a9025a7b775a069a6c0b0385c22ad51d3))))
+
+(expanded_solver_variable_bindings
+ (variable_values
+  (with-doc false)
+  (with-dev-setup false)
+  (sys-ocaml-version 5.2.0)
+  (post true)
+  (os-distribution arch)
+  (os linux)
+  (opam-version 2.2.0~alpha-vendored)
+  (arch x86_64))
+ (unset_variables
+  with-test
+  sys-ocaml-libc
+  sys-ocaml-cc
+  sys-ocaml-arch
+  enable-ocaml-beta-repository
+  dev
+  build))

--- a/dune.lock/logs.pkg
+++ b/dune.lock/logs.pkg
@@ -1,0 +1,27 @@
+(version 0.7.0)
+
+(build
+ (run
+  ocaml
+  pkg/pkg.ml
+  build
+  --pinned
+  %{pkg-self:pinned}
+  --with-js_of_ocaml
+  %{pkg:js_of_ocaml:installed}
+  --with-fmt
+  %{pkg:fmt:installed}
+  --with-cmdliner
+  %{pkg:cmdliner:installed}
+  --with-lwt
+  %{pkg:lwt:installed}
+  --with-base-threads
+  %{pkg:base-threads:installed}))
+
+(depends ocaml ocamlfind ocamlbuild topkg fmt cmdliner lwt base-threads)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/logs/releases/logs-0.7.0.tbz)
+  (checksum
+   sha256=86f4a02807eb1a297aae44977d9f61e419c31458a5d7b23c6f55575e8e69d5ca)))

--- a/dune.lock/lwt-dllist.pkg
+++ b/dune.lock/lwt-dllist.pkg
@@ -1,0 +1,13 @@
+(version 1.0.1)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/lwt-dllist/releases/download/v1.0.1/lwt-dllist-v1.0.1.tbz)
+  (checksum
+   sha256=e86ce75e40f00d51514cf8b2e71e5184c4cb5dae96136be24613406cfc0dba6e)))

--- a/dune.lock/lwt.pkg
+++ b/dune.lock/lwt.pkg
@@ -1,0 +1,33 @@
+(version 5.9.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run
+   dune
+   exec
+   -p
+   %{pkg-self:name}
+   src/unix/config/discover.exe
+   --
+   --save
+   --use-libev
+   %{pkg:conf-libev:installed})
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends
+ dune
+ ocaml
+ cppo
+ dune-configurator
+ ocplib-endian
+ base-threads
+ base-unix
+ conf-libev)
+
+(source
+ (fetch
+  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.9.0.tar.gz)
+  (checksum md5=763b9201c891f8c20ee02dec0af23355)))

--- a/dune.lock/lwt_ppx.pkg
+++ b/dune.lock/lwt_ppx.pkg
@@ -1,0 +1,15 @@
+(version 5.8.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml ppxlib lwt)
+
+(source
+ (fetch
+  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.8.1.tar.gz)
+  (checksum md5=d0f824f75ce5297975aec75366fed36c)))

--- a/dune.lock/lwt_ssl.pkg
+++ b/dune.lock/lwt_ssl.pkg
@@ -1,0 +1,13 @@
+(version 1.2.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends base-unix dune lwt ocaml ssl)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocsigen/lwt_ssl/releases/download/1.2.0/lwt_ssl-1.2.0.tbz)
+  (checksum
+   sha256=b3020ad27aecf377e1c3f2740a08b36dcbba991f843066511357410548889a77)))

--- a/dune.lock/macaddr.pkg
+++ b/dune.lock/macaddr.pkg
@@ -1,0 +1,17 @@
+(version 5.6.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-ipaddr/releases/download/v5.6.0/ipaddr-5.6.0.tbz)
+  (checksum
+   sha256=9e30433fdb4ca437a6aa8ffb447baca5eba7615fb88e7b0cd8a4b416c3208133)))

--- a/dune.lock/magic-mime.pkg
+++ b/dune.lock/magic-mime.pkg
@@ -1,0 +1,17 @@
+(version 1.3.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-magic-mime/releases/download/v1.3.1/magic-mime-1.3.1.tbz)
+  (checksum
+   sha256=e0234d03625dba1efac58e57e387672d75a5e9a621ff49acfe0f609c00f13b08)))

--- a/dune.lock/markup.pkg
+++ b/dune.lock/markup.pkg
@@ -1,0 +1,12 @@
+(version 1.0.3)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends dune ocaml uchar uutf)
+
+(source
+ (fetch
+  (url https://github.com/aantron/markup.ml/archive/1.0.3.tar.gz)
+  (checksum
+   sha256=9526fd06a0afc37d7ae6e2528787142d52b124238ffb0e7e8e83bdd383806eb5)))

--- a/dune.lock/menhir.pkg
+++ b/dune.lock/menhir.pkg
@@ -1,0 +1,12 @@
+(version 20240715)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune menhirLib menhirSdk menhirCST)
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz)
+  (checksum md5=d39a8943fe1be28199e5ec1f4133504c)))

--- a/dune.lock/menhirCST.pkg
+++ b/dune.lock/menhirCST.pkg
@@ -1,0 +1,12 @@
+(version 20240715)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz)
+  (checksum md5=d39a8943fe1be28199e5ec1f4133504c)))

--- a/dune.lock/menhirLib.pkg
+++ b/dune.lock/menhirLib.pkg
@@ -1,0 +1,12 @@
+(version 20240715)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz)
+  (checksum md5=d39a8943fe1be28199e5ec1f4133504c)))

--- a/dune.lock/menhirSdk.pkg
+++ b/dune.lock/menhirSdk.pkg
@@ -1,0 +1,12 @@
+(version 20240715)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://gitlab.inria.fr/fpottier/menhir/-/archive/20240715/archive.tar.gz)
+  (checksum md5=d39a8943fe1be28199e5ec1f4133504c)))

--- a/dune.lock/merlin-lib.pkg
+++ b/dune.lock/merlin-lib.pkg
@@ -1,0 +1,17 @@
+(version 5.3-502)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune csexp)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/merlin/releases/download/v5.3-502/merlin-5.3-502.tbz)
+  (checksum
+   sha256=2cea46f12397fa6e31ef0c0d4f5e11c1cfd916ee49420694005c95ebb3aa24bc)))

--- a/dune.lock/mirage-clock.pkg
+++ b/dune.lock/mirage-clock.pkg
@@ -1,0 +1,17 @@
+(version 4.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-clock/releases/download/v4.2.0/mirage-clock-4.2.0.tbz)
+  (checksum
+   sha256=fa17d15d5be23c79ba741f5f7cb88ed7112de16a4410cea81c71b98086889847)))

--- a/dune.lock/mirage-crypto-ec.pkg
+++ b/dune.lock/mirage-crypto-ec.pkg
@@ -1,0 +1,17 @@
+(version 1.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends dune ocaml dune-configurator eqaf mirage-crypto-rng digestif)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz)
+  (checksum
+   sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e)))

--- a/dune.lock/mirage-crypto-pk.pkg
+++ b/dune.lock/mirage-crypto-pk.pkg
@@ -1,0 +1,25 @@
+(version 1.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends
+ conf-gmp-powm-sec
+ ocaml
+ dune
+ mirage-crypto
+ mirage-crypto-rng
+ digestif
+ zarith
+ eqaf)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz)
+  (checksum
+   sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e)))

--- a/dune.lock/mirage-crypto-rng-lwt.pkg
+++ b/dune.lock/mirage-crypto-rng-lwt.pkg
@@ -1,0 +1,17 @@
+(version 1.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune duration logs mirage-crypto-rng mtime lwt)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz)
+  (checksum
+   sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e)))

--- a/dune.lock/mirage-crypto-rng.pkg
+++ b/dune.lock/mirage-crypto-rng.pkg
@@ -1,0 +1,17 @@
+(version 1.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune dune-configurator duration logs mirage-crypto digestif)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz)
+  (checksum
+   sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e)))

--- a/dune.lock/mirage-crypto.pkg
+++ b/dune.lock/mirage-crypto.pkg
@@ -1,0 +1,17 @@
+(version 1.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune dune-configurator eqaf)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/mirage-crypto/releases/download/v1.2.0/mirage-crypto-1.2.0.tbz)
+  (checksum
+   sha256=09542bcd96c1d368ff9ba8853105f4c1781d8c94c2400df9f3ac0610ee07e67e)))

--- a/dune.lock/mlx.pkg
+++ b/dune.lock/mlx.pkg
@@ -1,0 +1,30 @@
+(version 0.9)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run
+   dune
+   build
+   -p
+   %{pkg-self:name}
+   -j
+   %{jobs}
+   --promote-install-files=false
+   @install)
+  (run
+   dune
+   install
+   -p
+   %{pkg-self:name}
+   --create-install-files
+   %{pkg-self:name})))
+
+(depends ocaml ppxlib dune)
+
+(source
+ (fetch
+  (url https://github.com/ocaml-mlx/mlx/archive/refs/tags/0.9.tar.gz)
+  (checksum md5=c413c013d6c3a905e9b77cc2f65413cf)))

--- a/dune.lock/mtime.pkg
+++ b/dune.lock/mtime.pkg
@@ -1,0 +1,12 @@
+(version 2.1.0)
+
+(build
+ (run ocaml pkg/pkg.ml build --dev-pkg %{pkg-self:dev}))
+
+(depends ocaml ocamlfind ocamlbuild topkg)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/mtime/releases/mtime-2.1.0.tbz)
+  (checksum
+   sha512=a6619f1a3f1a5b32b7a9a067b939f94e6c66244eb90762d41f2cb1c9af852dd7d270fedb20e2b9b61875d52ba46e24af6ebf5950d1284b0b75b2fd2c380d9af3)))

--- a/dune.lock/multipart_form-lwt.pkg
+++ b/dune.lock/multipart_form-lwt.pkg
@@ -1,0 +1,13 @@
+(version 0.6.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune angstrom bigstringaf ke lwt multipart_form)
+
+(source
+ (fetch
+  (url
+   https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz)
+  (checksum
+   sha256=a0e329c323cffaad4167cd5af87a68a1e6a09546600f1773d8c0cd2f28062116)))

--- a/dune.lock/multipart_form.pkg
+++ b/dune.lock/multipart_form.pkg
@@ -1,0 +1,25 @@
+(version 0.6.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends
+ ocaml
+ dune
+ angstrom
+ base64
+ unstrctrd
+ uutf
+ pecu
+ prettym
+ fmt
+ logs
+ ke
+ bigstringaf)
+
+(source
+ (fetch
+  (url
+   https://github.com/dinosaure/multipart_form/releases/download/v0.6.0/multipart_form-0.6.0.tbz)
+  (checksum
+   sha256=a0e329c323cffaad4167cd5af87a68a1e6a09546600f1773d8c0cd2f28062116)))

--- a/dune.lock/ocaml-base-compiler.pkg
+++ b/dune.lock/ocaml-base-compiler.pkg
@@ -1,0 +1,27 @@
+(version 5.2.1)
+
+(install
+ (run %{make} install))
+
+(build
+ (progn
+  (run ./configure --prefix=%{prefix} --docdir=%{doc}/ocaml -C)
+  (run %{make} -j%{jobs})))
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/ocaml/releases/download/5.2.1/ocaml-5.2.1.tar.gz)
+  (checksum
+   sha256=2d0f8090951a97a2c0e5b8a11e90096c0e1791d2e471e4a67f87e3b974044cd0)))
+
+(exported_env
+ (= CAML_LD_LIBRARY_PATH "\%{lib}%/stublibs"))
+
+(extra_sources
+ (ocaml-base-compiler.install
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-base-compiler/ocaml-base-compiler.install)
+   (checksum
+    sha256=79f2a1a5044a91350a0eb6ce12e261a72a2855c094c425cddf3860e58c486678))))

--- a/dune.lock/ocaml-compiler-libs.pkg
+++ b/dune.lock/ocaml-compiler-libs.pkg
@@ -1,0 +1,12 @@
+(version v0.17.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/ocaml-compiler-libs/archive/refs/tags/v0.17.0.tar.gz)
+  (checksum md5=aaf66efea8752475c25a942443579b41)))

--- a/dune.lock/ocaml-config.pkg
+++ b/dune.lock/ocaml-config.pkg
@@ -1,0 +1,20 @@
+(version 3)
+
+(build
+ (substitute gen_ocaml_config.ml.in gen_ocaml_config.ml))
+
+(depends ocaml-base-compiler)
+
+(extra_sources
+ (gen_ocaml_config.ml.in
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/gen_ocaml_config.ml.in.3)
+   (checksum
+    sha256=a9ad8d84a08961159653a978db92d10f694510182b206cacb96d5c9f63b5121e)))
+ (ocaml-config.install
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/ocaml-config/ocaml-config.install)
+   (checksum
+    sha256=6e4fd93f4cce6bad0ed3c08afd0248dbe7d7817109281de6294e5b5ef5597051))))

--- a/dune.lock/ocaml-syntax-shims.pkg
+++ b/dune.lock/ocaml-syntax-shims.pkg
@@ -1,0 +1,17 @@
+(version 1.0.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-ppx/ocaml-syntax-shims/releases/download/1.0.0/ocaml-syntax-shims-1.0.0.tbz)
+  (checksum
+   sha256=89b2e193e90a0c168b6ec5ddf6fef09033681bdcb64e11913c97440a2722e8c8)))

--- a/dune.lock/ocaml.pkg
+++ b/dune.lock/ocaml.pkg
@@ -1,0 +1,19 @@
+(version 5.2.1)
+
+(build
+ (withenv
+  ((= CAML_LD_LIBRARY_PATH "")
+   (= LSAN_OPTIONS detect_leaks=0,exitcode=0)
+   (= ASAN_OPTIONS detect_leaks=0,exitcode=0))
+  (run
+   ocaml
+   %{pkg:ocaml-config:share}/gen_ocaml_config.ml
+   %{pkg-self:version}
+   %{pkg-self:name})))
+
+(depends ocaml-config ocaml-base-compiler)
+
+(exported_env
+ (= CAML_LD_LIBRARY_PATH "\%{_:stubsdir}%")
+ (+= CAML_LD_LIBRARY_PATH "\%{lib}%/stublibs")
+ (= OCAML_TOPLEVEL_PATH "\%{toplevel}%"))

--- a/dune.lock/ocamlbuild.pkg
+++ b/dune.lock/ocamlbuild.pkg
@@ -1,0 +1,25 @@
+(version 0.16.1+dune)
+
+(build
+ (progn
+  (run
+   %{make}
+   -f
+   configure.make
+   all
+   OCAMLBUILD_PREFIX=%{prefix}
+   OCAMLBUILD_BINDIR=%{bin}
+   OCAMLBUILD_LIBDIR=%{lib}
+   OCAMLBUILD_MANDIR=%{man}
+   OCAML_NATIVE=%{pkg:ocaml:native}
+   OCAML_NATIVE_TOOLS=%{pkg:ocaml:native})
+  (run %{make} check-if-preinstalled all opam-install)))
+
+(depends ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/gridbugs/ocamlbuild/archive/refs/tags/0.16.1+dune.tar.gz)
+  (checksum
+   sha512=9bf33e2e3cd70495c6ff5987f7e8c1c2fb3dccb02da490140726fed3b374489cb93d500f57bea32a1a71da1c9d3dd207e476109d1aaa759f54c3ef07d5b7ccd8)))

--- a/dune.lock/ocamlfind.pkg
+++ b/dune.lock/ocamlfind.pkg
@@ -1,0 +1,46 @@
+(version 1.9.8+dune)
+
+(install
+ (progn
+  (run %{make} install)
+  (when
+   %{pkg:ocaml:preinstalled}
+   (run install -m 0755 ocaml-stub %{bin}/ocaml))))
+
+(build
+ (progn
+  (run
+   ./configure
+   -bindir
+   %{bin}
+   -sitelib
+   %{lib}
+   -mandir
+   %{man}
+   -config
+   %{lib}/findlib.conf
+   -with-relative-paths-at
+   %{prefix}
+   -no-custom
+   (when
+    (catch_undefined_var
+     (and_absorb_undefined_var
+      (not %{pkg:ocaml:preinstalled})
+      (>= %{pkg:ocaml:version} 4.02.0))
+     false)
+    -no-camlp4)
+   (when
+    (catch_undefined_var %{pkg:ocaml:preinstalled} false)
+    -no-topfind))
+  (run %{make} all)
+  (when
+   %{pkg:ocaml:native}
+   (run %{make} opt))))
+
+(depends ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/ocamlfind/archive/refs/tags/findlib-1.9.8.tar.gz)
+  (checksum md5=ca770e5806032a96131b670f6e07f146)))

--- a/dune.lock/ocamlmerlin-mlx.pkg
+++ b/dune.lock/ocamlmerlin-mlx.pkg
@@ -1,0 +1,15 @@
+(version 0.9)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends ocaml ppxlib dune merlin-lib cppo)
+
+(source
+ (fetch
+  (url https://github.com/ocaml-mlx/mlx/archive/refs/tags/0.9.tar.gz)
+  (checksum md5=c413c013d6c3a905e9b77cc2f65413cf)))

--- a/dune.lock/ocplib-endian.pkg
+++ b/dune.lock/ocplib-endian.pkg
@@ -1,0 +1,12 @@
+(version 1.2)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs} @install))
+
+(depends base-bytes ocaml cppo dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/OCamlPro/ocplib-endian/archive/refs/tags/1.2.tar.gz)
+  (checksum md5=8d5492eeb7c6815ade72a7415ea30949)))

--- a/dune.lock/ohex.pkg
+++ b/dune.lock/ohex.pkg
@@ -1,0 +1,16 @@
+(version 0.2.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/opam-source-archives/raw/main/ohex-0.2.0.tar.gz)
+  (checksum md5=77f2cbe75b9efd528a2b3478a8d4f3d4)))

--- a/dune.lock/optint.pkg
+++ b/dune.lock/optint.pkg
@@ -1,0 +1,13 @@
+(version 0.3.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/optint/releases/download/v0.3.0/optint-0.3.0.tbz)
+  (checksum
+   sha256=295cff2c134b0385b13ba81d5005d9f841ba40d4a502aed10c997f239ef1147b)))

--- a/dune.lock/ordering.pkg
+++ b/dune.lock/ordering.pkg
@@ -1,0 +1,19 @@
+(version 3.17.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run rm -rf vendor/csexp)
+  (run rm -rf vendor/pp)
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
+  (checksum
+   sha256=9deafeed0ecfe9e65e642cd8e6197f0864f73fcd7b94b5b199ae4d2e07a2ea64)))

--- a/dune.lock/pecu.pkg
+++ b/dune.lock/pecu.pkg
@@ -1,0 +1,12 @@
+(version 0.7)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url https://github.com/mirage/pecu/releases/download/v0.7/pecu-0.7.tbz)
+  (checksum
+   sha256=ad7477b5b16428d33c32440067684953d94efaa43faaf620857918bace9fd778)))

--- a/dune.lock/pp.pkg
+++ b/dune.lock/pp.pkg
@@ -1,0 +1,16 @@
+(version 2.0.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml)
+
+(source
+ (fetch
+  (url https://github.com/ocaml-dune/pp/releases/download/2.0.0/pp-2.0.0.tbz)
+  (checksum
+   sha256=8651351518b092b4a2def4e08171c276152f92fb6a84a8b19b6b929ccdb44419)))

--- a/dune.lock/ppx_derivers.pkg
+++ b/dune.lock/ppx_derivers.pkg
@@ -1,0 +1,12 @@
+(version 1.2.1)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url https://github.com/ocaml-ppx/ppx_derivers/archive/1.2.1.tar.gz)
+  (checksum
+   sha256=b6595ee187dea792b31fc54a0e1524ab1e48bc6068d3066c45215a138cc73b95)))

--- a/dune.lock/ppx_deriving.pkg
+++ b/dune.lock/ppx_deriving.pkg
@@ -1,0 +1,17 @@
+(version 6.0.3)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune cppo ocamlfind ppx_derivers ppxlib)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-ppx/ppx_deriving/releases/download/v6.0.3/ppx_deriving-6.0.3.tbz)
+  (checksum
+   sha256=374aa97b32c5e01c09a97810a48bfa218c213b5b649e4452101455ac19c94a6d)))

--- a/dune.lock/ppx_deriving_yojson.pkg
+++ b/dune.lock/ppx_deriving_yojson.pkg
@@ -1,0 +1,17 @@
+(version 3.9.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune yojson ppx_deriving ppxlib)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-ppx/ppx_deriving_yojson/releases/download/v3.9.1/ppx_deriving_yojson-3.9.1.tbz)
+  (checksum
+   sha256=6a3ef7c7bb381f57448853f2a6d2287cf623628162a979587d1e8f7502114f4d)))

--- a/dune.lock/ppxlib.pkg
+++ b/dune.lock/ppxlib.pkg
@@ -1,0 +1,17 @@
+(version 0.35.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml ocaml-compiler-libs ppx_derivers sexplib0 stdlib-shims)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-ppx/ppxlib/releases/download/0.35.0/ppxlib-0.35.0.tbz)
+  (checksum
+   sha256=d9d959fc9f84260487e45684dc741898a92fc5506b61a7f5cac65d21832db925)))

--- a/dune.lock/prettym.pkg
+++ b/dune.lock/prettym.pkg
@@ -1,0 +1,13 @@
+(version 0.0.3)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune bigarray-overlap fmt ke bigstringaf)
+
+(source
+ (fetch
+  (url
+   https://github.com/dinosaure/prettym/releases/download/0.0.3/prettym-0.0.3.tbz)
+  (checksum
+   sha256=9170f1a11ade7f4d98a584a5be52bb6b91415f971c6e75894331b46b18b98f09)))

--- a/dune.lock/psq.pkg
+++ b/dune.lock/psq.pkg
@@ -1,0 +1,16 @@
+(version 0.2.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune seq)
+
+(source
+ (fetch
+  (url https://github.com/pqwy/psq/releases/download/v0.2.1/psq-0.2.1.tbz)
+  (checksum
+   sha256=42005f533eabe74b1799ee32b8905654cd66a22bed4af2bd266b28d8462cd344)))

--- a/dune.lock/ptime.pkg
+++ b/dune.lock/ptime.pkg
@@ -1,0 +1,12 @@
+(version 1.2.0)
+
+(build
+ (run ocaml pkg/pkg.ml build --dev-pkg %{pkg-self:dev}))
+
+(depends ocaml ocamlfind ocamlbuild topkg)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/ptime/releases/ptime-1.2.0.tbz)
+  (checksum
+   sha512=b0c3240dd9e777a5e60b5269eb2e312fc644d29ef55e257d2f2538c03bf62274173ed36e13858c44d2dbee8fe375c9c483e705706e4aa5b3b5c4609ca6324a5c)))

--- a/dune.lock/re.pkg
+++ b/dune.lock/re.pkg
@@ -1,0 +1,17 @@
+(version 1.12.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune seq)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/ocaml-re/releases/download/1.12.0/re-1.12.0.tbz)
+  (checksum
+   sha256=a01f2bf22f72c2f4ababd8d3e7635e35c1bf6bc5a41ad6d5a007454ddabad1d4)))

--- a/dune.lock/rresult.pkg
+++ b/dune.lock/rresult.pkg
@@ -1,0 +1,12 @@
+(version 0.7.0)
+
+(build
+ (run ocaml pkg/pkg.ml build --dev-pkg %{pkg-self:dev}))
+
+(depends ocaml ocamlfind ocamlbuild topkg)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/rresult/releases/rresult-0.7.0.tbz)
+  (checksum
+   sha512=f1bb631c986996388e9686d49d5ae4d8aaf14034f6865c62a88fb58c48ce19ad2eb785327d69ca27c032f835984e0bd2efd969b415438628a31f3e84ec4551d3)))

--- a/dune.lock/seq.pkg
+++ b/dune.lock/seq.pkg
@@ -1,0 +1,17 @@
+(version base)
+
+(depends ocaml)
+
+(extra_sources
+ (META.seq
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/META.seq)
+   (checksum
+    sha256=e95062b4d0519ef8335c02f7d0f1952d11b814c7ab7e6d566a206116162fa2be)))
+ (seq.install
+  (fetch
+   (url
+    https://raw.githubusercontent.com/ocaml/opam-source-archives/main/patches/seq/seq.install)
+   (checksum
+    sha256=fff926c2c4d5a82b6c94c60c4c35eb06e3d39975893ebe6b1f0e6557cbe34904))))

--- a/dune.lock/sexplib0.pkg
+++ b/dune.lock/sexplib0.pkg
@@ -1,0 +1,12 @@
+(version v0.17.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/janestreet/sexplib0/archive/refs/tags/v0.17.0.tar.gz)
+  (checksum md5=abafe8fd1d6302e55a315f4d78960d2a)))

--- a/dune.lock/sqlite3.pkg
+++ b/dune.lock/sqlite3.pkg
@@ -1,0 +1,17 @@
+(version 5.3.1)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml dune-configurator conf-sqlite3)
+
+(source
+ (fetch
+  (url
+   https://github.com/mmottl/sqlite3-ocaml/releases/download/5.3.1/sqlite3-5.3.1.tbz)
+  (checksum
+   sha256=3b1f1e652e2be8f6c987c9de8b9d9fb54c9fdb948ac0850c8b9504bf82feea61)))

--- a/dune.lock/ssl.pkg
+++ b/dune.lock/ssl.pkg
@@ -1,0 +1,15 @@
+(version 0.7.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml dune-configurator conf-libssl)
+
+(source
+ (fetch
+  (url https://github.com/savonet/ocaml-ssl/archive/refs/tags/v0.7.0.tar.gz)
+  (checksum md5=0ced13c2beef2135cd9d3a3743ea0e37)))

--- a/dune.lock/stdlib-shims.pkg
+++ b/dune.lock/stdlib-shims.pkg
@@ -1,0 +1,13 @@
+(version 0.3.0)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends dune ocaml)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/stdlib-shims/releases/download/0.3.0/stdlib-shims-0.3.0.tbz)
+  (checksum
+   sha256=babf72d3917b86f707885f0c5528e36c63fccb698f4b46cf2bab5c7ccdd6d84a)))

--- a/dune.lock/stdune.pkg
+++ b/dune.lock/stdune.pkg
@@ -1,0 +1,19 @@
+(version 3.17.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run rm -rf vendor/csexp)
+  (run rm -rf vendor/pp)
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml base-unix dyn ordering pp csexp)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/dune/releases/download/3.17.2/dune-3.17.2.tbz)
+  (checksum
+   sha256=9deafeed0ecfe9e65e642cd8e6197f0864f73fcd7b94b5b199ae4d2e07a2ea64)))

--- a/dune.lock/stringext.pkg
+++ b/dune.lock/stringext.pkg
@@ -1,0 +1,17 @@
+(version 1.6.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune)
+
+(source
+ (fetch
+  (url
+   https://github.com/rgrinberg/stringext/releases/download/1.6.0/stringext-1.6.0.tbz)
+  (checksum
+   sha256=db41f5d52e9eab17615f110b899dfeb27dd7e7f89cd35ae43827c5119db206ea)))

--- a/dune.lock/tailwindcss.pkg
+++ b/dune.lock/tailwindcss.pkg
@@ -1,0 +1,11 @@
+(version dev)
+
+(install
+ (run cp bin/tailwindcss-linux-x64 %{bin}/tailwindcss))
+
+(source
+ (fetch
+  (url
+   git+https://github.com/tmattio/opam-tailwindcss#e5bb6361a50c7cc5cad802311e609336583ca08f)))
+
+(dev)

--- a/dune.lock/tls.pkg
+++ b/dune.lock/tls.pkg
@@ -1,0 +1,31 @@
+(version 2.0.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends
+ ocaml
+ dune
+ mirage-crypto
+ mirage-crypto-ec
+ mirage-crypto-pk
+ mirage-crypto-rng
+ x509
+ domain-name
+ fmt
+ kdf
+ logs
+ ipaddr
+ ohex
+ digestif)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirleft/ocaml-tls/releases/download/v2.0.0/tls-2.0.0.tbz)
+  (checksum
+   sha256=68470d6ba8480075908c0cc69ffe82abbcbb83ab7f988d266335a19f12c26a62)))

--- a/dune.lock/topkg.pkg
+++ b/dune.lock/topkg.pkg
@@ -1,0 +1,19 @@
+(version 1.0.7)
+
+(build
+ (run
+  ocaml
+  pkg/pkg.ml
+  build
+  --pkg-name
+  %{pkg-self:name}
+  --dev-pkg
+  %{pkg-self:dev}))
+
+(depends ocaml ocamlfind ocamlbuild)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/topkg/releases/topkg-1.0.7.tbz)
+  (checksum
+   sha512=09e59f1759bf4db8471f02d0aefd8db602b44932a291c05c312b1423796e7a15d1598d3c62a0cec7f083eff8e410fac09363533dc4bd2120914bb9664efea535)))

--- a/dune.lock/uchar.pkg
+++ b/dune.lock/uchar.pkg
@@ -1,0 +1,19 @@
+(version 0.0.2)
+
+(build
+ (progn
+  (run ocaml pkg/git.ml)
+  (run
+   ocaml
+   pkg/build.ml
+   native=%{pkg:ocaml:native}
+   native-dynlink=%{pkg:ocaml:native-dynlink})))
+
+(depends ocaml ocamlbuild)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml/uchar/releases/download/v0.0.2/uchar-0.0.2.tbz)
+  (checksum
+   sha256=47397f316cbe76234af53c74a1f9452154ba3bdb54fced5caac959f50f575af0)))

--- a/dune.lock/unstrctrd.pkg
+++ b/dune.lock/unstrctrd.pkg
@@ -1,0 +1,13 @@
+(version 0.4)
+
+(build
+ (run dune build -p %{pkg-self:name} -j %{jobs}))
+
+(depends ocaml dune uutf angstrom)
+
+(source
+ (fetch
+  (url
+   https://github.com/dinosaure/unstrctrd/releases/download/v0.4/unstrctrd-0.4.tbz)
+  (checksum
+   sha256=368a9b86acea988e952fe7bdf5db2c9eaf5345a6939e609351f15eeb25121824)))

--- a/dune.lock/uri.pkg
+++ b/dune.lock/uri.pkg
@@ -1,0 +1,17 @@
+(version 4.4.0)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends ocaml dune stringext angstrom)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirage/ocaml-uri/releases/download/v4.4.0/uri-4.4.0.tbz)
+  (checksum
+   sha256=cdabaf6ef5cd2161e59cc7b74c6e4a68ecb80a9f4e96002e338e1b6bf17adec4)))

--- a/dune.lock/uutf.pkg
+++ b/dune.lock/uutf.pkg
@@ -1,0 +1,19 @@
+(version 1.0.3)
+
+(build
+ (run
+  ocaml
+  pkg/pkg.ml
+  build
+  --dev-pkg
+  %{pkg-self:dev}
+  --with-cmdliner
+  %{pkg:cmdliner:installed}))
+
+(depends ocaml ocamlfind ocamlbuild topkg cmdliner)
+
+(source
+ (fetch
+  (url https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz)
+  (checksum
+   sha512=50cc4486021da46fb08156e9daec0d57b4ca469b07309c508d5a9a41e9dbcf1f32dec2ed7be027326544453dcaf9c2534919395fd826dc7768efc6cc4bfcc9f8)))

--- a/dune.lock/x509.pkg
+++ b/dune.lock/x509.pkg
@@ -1,0 +1,33 @@
+(version 1.0.5)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs})))
+
+(depends
+ ocaml
+ dune
+ asn1-combinators
+ ptime
+ base64
+ mirage-crypto
+ mirage-crypto-pk
+ mirage-crypto-ec
+ mirage-crypto-rng
+ fmt
+ gmap
+ domain-name
+ logs
+ kdf
+ ohex
+ ipaddr)
+
+(source
+ (fetch
+  (url
+   https://github.com/mirleft/ocaml-x509/releases/download/v1.0.5/x509-1.0.5.tbz)
+  (checksum
+   sha256=efb09dbbe50e521ea2a9af34fcf28c1939bb6be9952254dcfd5294270c9a291b)))

--- a/dune.lock/yojson.pkg
+++ b/dune.lock/yojson.pkg
@@ -1,0 +1,17 @@
+(version 2.2.2)
+
+(build
+ (progn
+  (when
+   %{pkg-self:dev}
+   (run dune subst))
+  (run dune build -p %{pkg-self:name} -j %{jobs} @install)))
+
+(depends dune ocaml seq)
+
+(source
+ (fetch
+  (url
+   https://github.com/ocaml-community/yojson/releases/download/2.2.2/yojson-2.2.2.tbz)
+  (checksum
+   sha256=9abfad8c9a79d4723ad2f6448e669c1e68dbfc87cc54a1b7c064b0c90912c595)))

--- a/dune.lock/zarith.pkg
+++ b/dune.lock/zarith.pkg
@@ -1,0 +1,17 @@
+(version 1.14)
+
+(install
+ (run %{make} install))
+
+(build
+ (progn
+  (run ./configure)
+  (run %{make})))
+
+(depends ocaml ocamlfind conf-pkg-config conf-gmp)
+
+(source
+ (fetch
+  (url https://github.com/ocaml/Zarith/archive/release-1.14.tar.gz)
+  (checksum
+   sha256=5db9dcbd939153942a08581fabd846d0f3f2b8c67fe68b855127e0472d4d1859)))


### PR DESCRIPTION
This PR allows `sandworm`, the binary in charge of synchronizing dune artifacts for the preview, to be built using the latest nightly built dune. It shows that dune pkg management is using in "production".
This change does only build the binary inside the GitHub Actions. It does not try to build the web server within the Dockerfile. This would be for another PR.

Superseed #42
