### PR TITLE
chore(tailwindcss): move to targz lighter URL

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -59,6 +59,6 @@
 
 (pin
  (url
-  "git+https://github.com/tmattio/opam-tailwindcss#e5bb6361a50c7cc5cad802311e609336583ca08f")
+   "https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz")
  (package
   (name tailwindcss)))

--- a/dune.lock/lock.dune
+++ b/dune.lock/lock.dune
@@ -10,13 +10,12 @@
   ((source
     https://github.com/ocaml-dune/opam-overlays.git#a538aecc5f1c4a775c41ea156d96bfd173caa43b))
   ((source
-    https://github.com/ocaml/opam-repository.git#8f63148a9025a7b775a069a6c0b0385c22ad51d3))))
+    https://github.com/ocaml/opam-repository.git#4d8fa0fb8fce3b6c8b06f29ebcfa844c292d4f3e))))
 
 (expanded_solver_variable_bindings
  (variable_values
   (with-doc false)
   (with-dev-setup false)
-  (sys-ocaml-version 5.2.0)
   (post true)
   (os-distribution arch)
   (os linux)
@@ -24,9 +23,8 @@
   (arch x86_64))
  (unset_variables
   with-test
+  sys-ocaml-version
   sys-ocaml-libc
-  sys-ocaml-cc
-  sys-ocaml-arch
   enable-ocaml-beta-repository
   dev
   build))

--- a/dune.lock/logs.pkg
+++ b/dune.lock/logs.pkg
@@ -1,14 +1,14 @@
-(version 0.7.0)
+(version 0.8.0)
 
 (build
  (run
   ocaml
   pkg/pkg.ml
   build
-  --pinned
-  %{pkg-self:pinned}
-  --with-js_of_ocaml
-  %{pkg:js_of_ocaml:installed}
+  --dev-pkg
+  %{pkg-self:dev}
+  --with-js_of_ocaml-compiler
+  %{pkg:js_of_ocaml-compiler:installed}
   --with-fmt
   %{pkg:fmt:installed}
   --with-cmdliner
@@ -18,10 +18,10 @@
   --with-base-threads
   %{pkg:base-threads:installed}))
 
-(depends ocaml ocamlfind ocamlbuild topkg fmt cmdliner lwt base-threads)
+(depends ocaml ocamlfind ocamlbuild topkg cmdliner fmt lwt base-threads)
 
 (source
  (fetch
-  (url https://erratique.ch/software/logs/releases/logs-0.7.0.tbz)
+  (url https://erratique.ch/software/logs/releases/logs-0.8.0.tbz)
   (checksum
-   sha256=86f4a02807eb1a297aae44977d9f61e419c31458a5d7b23c6f55575e8e69d5ca)))
+   sha512=c34c67b00d6a989a2660204ea70db8521736d6105f15d1ee0ec6287a662798fe5c4d47075c6e7c84f5d5372adb5af5c4c404f79db70d69140af5e0ebbea3b6a5)))

--- a/dune.lock/lwt.pkg
+++ b/dune.lock/lwt.pkg
@@ -1,4 +1,4 @@
-(version 5.9.0)
+(version 5.9.1)
 
 (build
  (progn
@@ -29,5 +29,5 @@
 
 (source
  (fetch
-  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.9.0.tar.gz)
-  (checksum md5=763b9201c891f8c20ee02dec0af23355)))
+  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.9.1.tar.gz)
+  (checksum md5=18742da8b8fe3618e3fa700b7a884fe7)))

--- a/dune.lock/lwt_ppx.pkg
+++ b/dune.lock/lwt_ppx.pkg
@@ -1,4 +1,4 @@
-(version 5.8.1)
+(version 5.9.1)
 
 (build
  (progn
@@ -11,5 +11,5 @@
 
 (source
  (fetch
-  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.8.1.tar.gz)
-  (checksum md5=d0f824f75ce5297975aec75366fed36c)))
+  (url https://github.com/ocsigen/lwt/archive/refs/tags/5.9.1.tar.gz)
+  (checksum md5=18742da8b8fe3618e3fa700b7a884fe7)))

--- a/dune.lock/tailwindcss.pkg
+++ b/dune.lock/tailwindcss.pkg
@@ -6,6 +6,7 @@
 (source
  (fetch
   (url
-   git+https://github.com/tmattio/opam-tailwindcss#e5bb6361a50c7cc5cad802311e609336583ca08f)))
+   https://github.com/tmattio/opam-tailwindcss/archive/e5bb6361a50c7cc5cad802311e609336583ca08f.tar.gz)
+  (checksum md5=189bc9057283664bbca286a3836868a6)))
 
 (dev)

--- a/dune.lock/topkg.pkg
+++ b/dune.lock/topkg.pkg
@@ -1,4 +1,4 @@
-(version 1.0.7)
+(version 1.0.8)
 
 (build
  (run
@@ -14,6 +14,6 @@
 
 (source
  (fetch
-  (url https://erratique.ch/software/topkg/releases/topkg-1.0.7.tbz)
+  (url https://erratique.ch/software/topkg/releases/topkg-1.0.8.tbz)
   (checksum
-   sha512=09e59f1759bf4db8471f02d0aefd8db602b44932a291c05c312b1423796e7a15d1598d3c62a0cec7f083eff8e410fac09363533dc4bd2120914bb9664efea535)))
+   sha512=4b632b60137852bb72ff9c8cdc2e16ac5ece6473569e50963fef9c1e800a0933a516bea1107b04011645afa4a1e78893c82dbce0aa8de2970d4d6c6d0dd2fe02)))

--- a/dune.lock/uutf.pkg
+++ b/dune.lock/uutf.pkg
@@ -1,4 +1,4 @@
-(version 1.0.3)
+(version 1.0.4)
 
 (build
  (run
@@ -14,6 +14,6 @@
 
 (source
  (fetch
-  (url https://erratique.ch/software/uutf/releases/uutf-1.0.3.tbz)
+  (url https://erratique.ch/software/uutf/releases/uutf-1.0.4.tbz)
   (checksum
-   sha512=50cc4486021da46fb08156e9daec0d57b4ca469b07309c508d5a9a41e9dbcf1f32dec2ed7be027326544453dcaf9c2534919395fd826dc7768efc6cc4bfcc9f8)))
+   sha512=e35f408bc971cd8da3077e6c3321e0d8f4eb569898e0e219fde62dae78fbd0a0095cb7f036287656f6a1b346584f7b9f0c6dec0a5a092180da36e43247027598)))


### PR DESCRIPTION
Now Dune Package Management is able to use tar URL, it is a good idea to go
back to the tailwind tar.gz URL to make sure we don't download an history of
executables.

Fixes #135
