### PR TITLE
fix: ensure compopt available

### DIFF
--- a/completions/bash.sh
+++ b/completions/bash.sh
@@ -62,7 +62,7 @@ test "$_dune_h" -gt "$COMP_CWORD"
 }
 _dune_n() {
 COMPREPLY+=($(compgen -A file -- "$1"))
-compopt -o filenames
+type compot &> /dev/null && complopt -o filenames
 }
 _dune_o() {
 COMPREPLY+=($(compgen -W "$2" -- "$1"))


### PR DESCRIPTION
This PR adds a guard against `compopt` as it can be not available in old bash version and in zsh (see [issue](https://github.com/crystal-lang/crystal/issues/12232)).
