### PR TITLE
web: add the new binary flag

### DIFF
--- a/lib/main.mlx
+++ b/lib/main.mlx
@@ -197,6 +197,7 @@ let q_and_a = [
       <Code>
 "--enable-pkg-build-progress"
 "--enable-lock-dev-tool"
+"--enable-bin-dev-tools"
 </Code>
     </div>
   ; "Can I access these features from a version of Dune managed by opam?",


### PR DESCRIPTION
This PR introduces the new binary dev tools flag to the website.
