### PR TITLE
fix: use the correct flag names

### DIFF
--- a/lib/main.mlx
+++ b/lib/main.mlx
@@ -195,9 +195,9 @@ let q_and_a = [
       </p>
       <p>"When configuring the build you'll want to enable the following flags:" </p>
       <Code>
-"--enable-pkg-build-progress"
-"--enable-lock-dev-tool"
-"--enable-bin-dev-tools"
+"--pkg-build-progress enable"
+"--lock-dev-tool enable"
+"--bin-dev-tools enable"
 </Code>
     </div>
   ; "Can I access these features from a version of Dune managed by opam?",


### PR DESCRIPTION
The flag section was using the old syntax. 