### PR TITLE
Mention portable lock dirs

### DIFF
--- a/lib/main.mlx
+++ b/lib/main.mlx
@@ -198,6 +198,7 @@ let q_and_a = [
 "--pkg-build-progress enable"
 "--lock-dev-tool enable"
 "--bin-dev-tools enable"
+"--portable-lock-dirs enable"
 </Code>
     </div>
   ; "Can I access these features from a version of Dune managed by opam?",


### PR DESCRIPTION
Outdated documentation pointed out by @shym.