### PR TITLE
Don't mention binary dev tools anymore, they're not enabled anymore

### DIFF
--- a/lib/main.mlx
+++ b/lib/main.mlx
@@ -197,7 +197,6 @@ let q_and_a = [
       <Code>
 "--pkg-build-progress enable"
 "--lock-dev-tool enable"
-"--bin-dev-tools enable"
 "--portable-lock-dirs enable"
 </Code>
     </div>
@@ -211,7 +210,6 @@ let q_and_a = [
 "$ opam pin add dune --dev"
 "$ export DUNE_CONFIG__PKG_BUILD_PROGRESS=enabled"
 "$ export DUNE_CONFIG__LOCK_DEV_TOOL=enabled"
-"$ export DUNE_CONFIG__BIN_DEV_TOOLS=enabled"
 "$ export DUNE_CONFIG__PORTABLE_LOCK_DIRS=enabled"
 </Code>
     </div>


### PR DESCRIPTION
Disabled in https://github.com/ocaml/dune/pull/11882