### PR TITLE
Fix issue with paste on macOS

### DIFF
--- a/tool-wrappers/ocamllsp
+++ b/tool-wrappers/ocamllsp
@@ -32,7 +32,7 @@ else
     script_dir="$(dirname "$0")"
 
     # Remove the directory containing this script from PATH so it doesn't call itself
-    path_without_script_dir=$(echo "$PATH" | tr ':' '\n' | grep -v "^$script_dir$" | paste -sd ':')
+    path_without_script_dir=$(echo "$PATH" | tr ':' '\n' | grep -v "^$script_dir$" | paste -sd ':' -)
     export PATH="$path_without_script_dir"
 
     if type opam 2> /dev/null > /dev/null; then


### PR DESCRIPTION
A recent update to macOS appears to have changed the paste command so that it no longer assumes its inputs is stdin when no input file is specified. It does still follow the convention of interpreting an input file named "-" as stdin, so the fix is to pass "-" as the input file to paste.