### PR TITLE
Serve install script (only) from Dream server

### DIFF
--- a/bin/config.ml
+++ b/bin/config.ml
@@ -12,5 +12,4 @@ module Path = struct
   let artifacts_dir = "./artifacts"
   let metadata = "./metadata.json"
   let rclone = "./rclone.conf"
-  let install = "./static/install"
 end

--- a/bin/config.ml
+++ b/bin/config.ml
@@ -1,7 +1,11 @@
 module Server = struct
   let bucket_dir = "/dune/"
   let rclone_bucket_ref = Format.sprintf "dune-binary-distribution:%s" bucket_dir
-  let url = "https://get.dune.build"
+  let artifact_base_url = "https://get.dune.build"
+end
+
+module Site = struct
+  let install_script_url = "https://nightly.dune.build/install"
 end
 
 module Path = struct

--- a/bin/config.mli
+++ b/bin/config.mli
@@ -1,6 +1,10 @@
 module Server : sig
   val rclone_bucket_ref : string
-  val url : string
+  val artifact_base_url : string
+end
+
+module Site : sig
+  val install_script_url : string
 end
 
 module Path : sig

--- a/bin/config.mli
+++ b/bin/config.mli
@@ -11,5 +11,4 @@ module Path : sig
   val artifacts_dir : string
   val metadata : string
   val rclone : string
-  val install : string
 end

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -51,25 +51,6 @@ module Sync = struct
           Config.Path.artifacts_dir
           s3_daily_bundle
     in
-    let () =
-      let install_bucket_path =
-        Filename.concat
-          Config.Server.rclone_bucket_ref
-          (Filename.basename Config.Path.install)
-      in
-      if dry_run
-      then
-        Format.printf
-          "- Copy file (%s) to %s, using RClone (%s)\n"
-          Config.Path.install
-          install_bucket_path
-          Config.Path.rclone
-      else
-        Rclone.copy
-          ~config_path:Config.Path.rclone
-          Config.Path.install
-          install_bucket_path
-    in
     let bundles = Metadata.insert_unique daily_bundle bundle in
     let () =
       if dry_run

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -98,16 +98,19 @@ end
 module Http = struct
   let serve dev metadata_file port =
     let title = "Dune Nightly" in
-    let base_url = Config.Server.url in
+    let artifact_base_url = Config.Server.artifact_base_url in
+    let install_script_url = Config.Site.install_script_url in
     let bundles = Metadata.import_from_json metadata_file in
     let routes =
-      let main_page = Web.generate_main_page ~title ~base_url bundles in
+      let main_page =
+        Web.generate_main_page ~title ~artifact_base_url ~install_script_url bundles
+      in
       Web.Route.empty
       |> Web.Route.add ~path:"/" main_page
       |> Web.Route.add ~path:"/index.html" main_page
     in
     let latest = List.hd bundles in
-    Server.serve ~dev ~base_url routes port latest
+    Server.serve ~dev ~artifact_base_url routes port latest
   ;;
 
   let term =

--- a/bin/server.ml
+++ b/bin/server.ml
@@ -13,13 +13,13 @@ let reload_script_middleware ~dev inner_handler request =
   if dev then Dream.livereload inner_handler request else inner_handler request
 ;;
 
-let latest_route_from_targets ~base_url bundle =
+let latest_route_from_targets ~artifact_base_url bundle =
   let open Sandworm.Metadata in
   List.map
     (fun target ->
-      let path = Format.sprintf "/%s" (Target.to_string target) in
-      Dream.get path (fun request ->
-        Dream.redirect request (Bundle.to_download_url ~base_url ~target bundle)))
+       let path = Format.sprintf "/%s" (Target.to_string target) in
+       Dream.get path (fun request ->
+         Dream.redirect request (Bundle.to_download_url ~artifact_base_url ~target bundle)))
     bundle.targets
 ;;
 
@@ -39,7 +39,7 @@ let from_tuple_to_dream page =
   List.map (fun (path, content) -> Dream.get path (fun _ -> Dream.html content)) page
 ;;
 
-let serve ~dev ~base_url routes port bundle =
+let serve ~dev ~artifact_base_url routes port bundle =
   let interface = if dev then "127.0.0.1" else "0.0.0.0" in
   let error_handler = Dream.error_template error_template in
   Dream.log
@@ -56,6 +56,6 @@ let serve ~dev ~base_url routes port bundle =
         @ [ Dream.get "/health" (fun _ -> Dream.html "OK")
           ; Dream.get "/install" (fun request -> Dream.redirect request "/static/install")
           ; Dream.get "/static/**" @@ Dream.static "static"
-          ; Dream.scope "/latest" [] (latest_route_from_targets ~base_url bundle)
+          ; Dream.scope "/latest" [] (latest_route_from_targets ~artifact_base_url bundle)
           ])
 ;;

--- a/lib/main.mlx
+++ b/lib/main.mlx
@@ -38,7 +38,7 @@ let warning () =
   </div>
 
 
-let getting_started ~install_url () =
+let getting_started ~install_script_url () =
   <section id="download" class_="w-full flex justify-center pt-9 pb-12 px-5 lg:px-0">
     <div class_="w-full lg:w-lg flex flex-col">
     <h2 class_="mb-5">"Install Dune"</h2>
@@ -46,7 +46,7 @@ let getting_started ~install_url () =
       <span class_="mr-2.5"><Icons.terminal /></span>
       "Copy & Install"
     </h4>
-    <Curl script=(Info.curl_with_sh install_url) />
+    <Curl script=(Info.curl_with_sh install_script_url) />
     <h3 class_="mt-10 mb-2.5">"Getting Started"</h3>
     <p>"You can create and run your first hello-world program using Dune like this"</p>
     <h4 class_="mt-2.5">
@@ -216,13 +216,13 @@ let faq () =
   </div>
   </section>
 
-let installation_target ~base_url ~bundle target =
+let installation_target ~artifact_base_url ~bundle target =
   let open Metadata in
   let title = Target.to_human_readable_string target in
   let desc = Target.to_description target in
   let targz = Bundle.to_download_file target in
-  let cert_href = Bundle.to_certificate_url bundle ~base_url ~target in
-  let tar_href = Bundle.to_download_url bundle ~base_url ~target  in
+  let cert_href = Bundle.to_certificate_url bundle ~artifact_base_url ~target in
+  let tar_href = Bundle.to_download_url bundle ~artifact_base_url ~target  in
   <li class_="w-[420px] flex flex-col justify-center items-end">
     <div class_="w-full h-[140px] px-4 py-2 mb-2.5 gap-y-2.5 flex flex-col justify-center items-center border-[2px] border-solid border-primary-light rounded-md bg-white">
       <h4 class_="font-bold">(JSX.string title)</h4>
@@ -237,7 +237,7 @@ let installation_target ~base_url ~bundle target =
     <a class_="text-black underline hover:text-primary-light" href=cert_href>"Certificate"</a>
   </li>
 
-let manual_installation ~base_url ~releases () =
+let manual_installation ~artifact_base_url ~releases () =
   <section id="manual-installation" class_="w-full flex justify-center border-t border-b border-black/20 py-10  bg-section-manual px-5 lg:px-0">
     <div class_="w-full lg:w-lg flex flex-col gap-2 ">
     <h2 class_="mb-2"> "Manual Installation" </h2>
@@ -253,7 +253,7 @@ let manual_installation ~base_url ~releases () =
     <ul class_="flex flex-row gap-2.5 justify-around flex-wrap items-center align-center mb-5">
       (let bundle: Metadata.Bundle.t = releases |> List.hd in
       bundle.targets
-       |> List.map (installation_target ~base_url ~bundle)
+       |> List.map (installation_target ~artifact_base_url ~bundle)
        |> JSX.list)
     </ul>
 
@@ -286,11 +286,11 @@ let manual_installation ~base_url ~releases () =
   </section>
 
 
-let release_information ~base_url ~bundle ~target () =
+let release_information ~artifact_base_url ~bundle ~target () =
   let open Metadata in
   let targz = Bundle.to_download_file target in
-  let cert_href = Bundle.to_certificate_url bundle ~base_url ~target in
-  let tar_href = Bundle.to_download_url bundle ~base_url ~target  in
+  let cert_href = Bundle.to_certificate_url bundle ~artifact_base_url ~target in
+  let tar_href = Bundle.to_download_url bundle ~artifact_base_url ~target  in
   let (arch, _, os) = Target.to_triple target in
   <tr class_="odd:bg-tertiary/10">
     <td class_="pl-2.5 lg:pl-14 border"><Link class_="hover:underline" href=tar_href>(JSX.string targz)</Link></td>
@@ -307,7 +307,7 @@ let release_information ~base_url ~bundle ~target () =
   </tr>
 
 
-let release_history ~base_url ~releases () =
+let release_history ~artifact_base_url ~releases () =
   let open Metadata in
   <section id="release-history" class_="w-full flex justify-center py-10 px-5 lg:px-0">
     <div class_="w-full lg:w-lg flex flex-col gap-2 text-left">
@@ -323,7 +323,7 @@ let release_history ~base_url ~releases () =
       |> List.map (fun (bundle: Bundle.t) ->
           let date = Bundle.get_date_string_from ~prefix:"nightly-" bundle in
           let summary = Format.sprintf "dune %s" date in
-          let files = bundle.targets |> List.map (fun (target: Target.t) -> (<release_information base_url bundle target />)) in
+          let files = bundle.targets |> List.map (fun (target: Target.t) -> (<release_information artifact_base_url bundle target />)) in
           (<Details summary container_class="w-full overflow-scroll">
              <table class_="w-full pb-4 border-collapse border">
                 <thead class_="font-normal border">
@@ -347,15 +347,14 @@ let release_history ~base_url ~releases () =
   </div>
   </section>
 
-let page ~base_url ~releases () =
+let page ~artifact_base_url ~install_script_url ~releases () =
   let releases = Core.List.take 30 releases in
-  let install_url = Filename.concat base_url "install" in
   <main class_="flex flex-col w-full">
     <header_info />
     <warning />
-    <getting_started install_url />
+    <getting_started install_script_url />
     <feedback />
     <faq />
-    <manual_installation base_url releases />
-    <release_history base_url releases />
+    <manual_installation artifact_base_url releases />
+    <release_history artifact_base_url releases />
   </main>

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -76,12 +76,12 @@ module Bundle = struct
 
   let ( / ) = Filename.concat
 
-  let to_url ~base_url ~target t =
-    base_url / get_date_string_from t / Target.to_string target
+  let to_url ~artifact_base_url ~target t =
+    artifact_base_url / get_date_string_from t / Target.to_string target
   ;;
 
-  let to_certificate_url ~base_url ~target t =
-    to_url ~base_url ~target t / "attestation.jsonl"
+  let to_certificate_url ~artifact_base_url ~target t =
+    to_url ~artifact_base_url ~target t / "attestation.jsonl"
   ;;
 
   let download_file_name ~date arch =
@@ -90,10 +90,10 @@ module Bundle = struct
     | Some date -> Format.sprintf "dune-%s-%s.tar.gz" date arch
   ;;
 
-  let to_download_url ~base_url ~target t =
+  let to_download_url ~artifact_base_url ~target t =
     let date = get_date_string_from t |> Option.some in
     let arch = Target.to_string target in
-    to_url ~base_url ~target t / download_file_name ~date arch
+    to_url ~artifact_base_url ~target t / download_file_name ~date arch
   ;;
 
   let to_download_file target =

--- a/lib/web.ml
+++ b/lib/web.ml
@@ -1,7 +1,8 @@
 let export_website_to_string ~title content = Container.page ~title content |> JSX.render
 
-let generate_main_page ~title ~base_url releases =
-  Main.page ~base_url ~releases () |> export_website_to_string ~title
+let generate_main_page ~title ~artifact_base_url ~install_script_url releases =
+  Main.page ~artifact_base_url ~install_script_url ~releases ()
+  |> export_website_to_string ~title
 ;;
 
 let generate_error_page ~title ~code reason =


### PR DESCRIPTION
This PR moves the install script from the `get.dune.build` server to the script served by `nightly.dune.build`.

The previous setup used to copy the `install` script to `get.dune.build` as part of the daily sync action, but this has some distinct disadvantages

1. Once a change to the install script is merged, it takes for the `sync` action to run until the new version is deployed. This two step process is tricky because it is easy to forget to run the action and then the script will only be updated on the next run (which might only happen after a few days if no changes to dune occur). This means that it can take multiple days until a change happens and things can be broken for a longer time (e.g. change over the weekend)
2. It's rather complicated to understand. It is fairly understandable that `get.dune.build` is used to host the binaries, but the fact that the install script is served by both the `binary-distribution` Dream app (which serves the most currently deployed `main` version) as well as `get.dune.build` (the latest version from the github action) is confusing. This simplifies the code base to always just use one of them.