### PR TITLE
Update the location of the attestation files

### DIFF
--- a/lib/main.mlx
+++ b/lib/main.mlx
@@ -296,7 +296,7 @@ let manual_installation ~base_url ~builds () =
       <span class_="font-mono text-block-p">"gh"</span>
       <span>" tool to verify it with the following command: "</span>
     </p>
-    <Code>[JSX.string "$ gh attestation verify ./dune -R ocaml-dune/binary-distribution --bundle attestation.jsonl"]</Code>
+    <Code>[JSX.string "$ gh attestation verify ./dune -R ocaml-dune/binary-distribution --bundle attestation.json"]</Code>
   </div>
   </section>
 

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -168,7 +168,7 @@ module Bundle = struct
 
   let to_certificate_url ~base_url ~target t =
     let date = get_date_string_from t in
-    to_nightly_url ~base_url ~target ~date / "attestation.jsonl"
+    to_nightly_url ~base_url ~target ~date / "attestation.json"
   ;;
 
   let download_nightly_name ~date arch =


### PR DESCRIPTION
The new attestation actions use `attestation.json` as filename instead of `attestation.jsonl`; this PR fixes the location that is shown on the web site.

Closes #227.