### PR TITLE
Use the host that is behind CloudFront

### DIFF
--- a/rclone.conf
+++ b/rclone.conf
@@ -1,5 +1,5 @@
 [dune-binary-distribution]
 type = sftp
-host = get.dune.build
+host = 128.232.124.216
 user = github-actions
 key_file = /home/runner/.ssh/tarides


### PR DESCRIPTION
The issue with connectivity for GitHub Actions was solved by putting `get.dune.build` behind CloudFront. However this means that the server is not reachable via SSH that way.

After consultation @mtelvers told me to use 128.232.124.216 instead, so I adjusted the `DEPLOY_SERVER` secret which allowed SSH-Keyscan to succeed, however deployment of the binaries still failed as the configuration is read from `rclone.conf` and needs to be adapted here as well.