### PR TITLE
Add aarch64-unknown-linux-musl target

### DIFF
--- a/.github/workflows/binary-nightly.yaml
+++ b/.github/workflows/binary-nightly.yaml
@@ -153,7 +153,11 @@ jobs:
 
       - name: Check dune is working
         run: |
-          export PATH="$HOME/.local/bin:$PATH"
+          local_bin="$HOME/.local/bin"
+          export PATH="$local_bin:$PATH"
+          file "$local_bin/dune"
+          ldd "$local_bin/dune"
+          which dune
           cd binary-distribution/test
           dune --version
           dune pkg lock --root .

--- a/.github/workflows/binary-nightly.yaml
+++ b/.github/workflows/binary-nightly.yaml
@@ -71,8 +71,8 @@ jobs:
 
       - uses: actions/checkout@v6
         with:
-          repository: ocaml/dune
-          ref: main
+          repository: Leonidas-from-XIV/dune
+          ref: aarch64-cross-nix
           fetch-depth: 0 # for git describe
 
       - name: Checkout

--- a/.github/workflows/binary-nightly.yaml
+++ b/.github/workflows/binary-nightly.yaml
@@ -50,6 +50,9 @@ jobs:
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
+          - os: ubuntu-22.04-arm
+            name: aarch64-unknown-linux-musl
+            installable: .#dune-static
 
     # If the latest commit is the same as latest run, don't re-run.
     if: ${{ needs.check_build.outputs.action == 'BUILD' || github.event_name == 'workflow_dispatch' }}
@@ -124,6 +127,8 @@ jobs:
             name: aarch64-apple-darwin
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
+          - os: ubuntu-22.04-arm
+            name: aarch64-unknown-linux-musl
 
     runs-on: ${{ matrix.os }}
     needs: binary

--- a/.github/workflows/binary-stable.yaml
+++ b/.github/workflows/binary-stable.yaml
@@ -84,6 +84,9 @@ jobs:
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
+          - os: ubuntu-22.04-arm
+            name: aarch64-unknown-linux-musl
+            installable: .#dune-static
 
     # if we have nothing new to build, skip
     if: ${{ needs.check_build.outputs.action == 'BUILD' }}
@@ -147,6 +150,8 @@ jobs:
             name: aarch64-apple-darwin
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
+          - os: ubuntu-22.04-arm
+            name: aarch64-unknown-linux-musl
 
     runs-on: ${{ matrix.os }}
     needs: [check_build, binary]

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -1,18 +1,21 @@
 module Target = struct
   type t =
     | Aarch64_apple_darwin
+    | Aarch64_unknown_linux_musl
     | X86_64_apple_darwin
     | X86_64_unknown_linux_musl
   [@@deriving yojson]
 
   let to_string = function
     | Aarch64_apple_darwin -> "aarch64-apple-darwin"
+    | Aarch64_unknown_linux_musl -> "aarch64-unknown-linux-musl"
     | X86_64_apple_darwin -> "x86_64-apple-darwin"
     | X86_64_unknown_linux_musl -> "x86_64-unknown-linux-musl"
   ;;
 
   let of_string = function
     | "aarch64-apple-darwin" -> Some Aarch64_apple_darwin
+    | "aarch64-unknown-linux-musl" -> Some Aarch64_unknown_linux_musl
     | "x86_64-apple-darwin" -> Some X86_64_apple_darwin
     | "x86_64-unknown-linux-musl" -> Some X86_64_unknown_linux_musl
     | _ -> None
@@ -20,23 +23,31 @@ module Target = struct
 
   let to_human_readable_string = function
     | Aarch64_apple_darwin -> "Apple macOS (ARM64)"
+    | Aarch64_unknown_linux_musl -> "Linux (ARM64, musl)"
     | X86_64_apple_darwin -> "Apple macOS (x86-64)"
     | X86_64_unknown_linux_musl -> "Linux (x86-64, musl)"
   ;;
 
   let to_description = function
     | Aarch64_apple_darwin -> "macOS 11 or later for Apple silicon processors"
+    | Aarch64_unknown_linux_musl -> "Linux for ARM 64-bit processors"
     | X86_64_apple_darwin -> "macOS 11 or later for Intel processors"
     | X86_64_unknown_linux_musl -> "Linux for Intel 64-bit processors"
   ;;
 
   let to_triple = function
     | Aarch64_apple_darwin -> "aarch64", "apple", "macOS"
+    | Aarch64_unknown_linux_musl -> "aarch64", "unknown", "Linux"
     | X86_64_apple_darwin -> "x86-64", "apple", "macOS"
     | X86_64_unknown_linux_musl -> "x86-64", "unknown", "Linux"
   ;;
 
-  let defaults = [ Aarch64_apple_darwin; X86_64_apple_darwin; X86_64_unknown_linux_musl ]
+  let defaults =
+    [ Aarch64_apple_darwin
+    ; Aarch64_unknown_linux_musl
+    ; X86_64_apple_darwin
+    ; X86_64_unknown_linux_musl
+    ]
 end
 
 module Pdate = struct

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -48,6 +48,7 @@ module Target = struct
     ; X86_64_apple_darwin
     ; X86_64_unknown_linux_musl
     ]
+  ;;
 end
 
 module Pdate = struct


### PR DESCRIPTION
Static dune binaries (musl) for *ARM64* Linux. 
