### PR TITLE
Fix cmdliner flag

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -4,7 +4,7 @@ open Cmdliner
 module Common_args = struct
   let testing =
     let doc = "Run in test configuration." in
-    Arg.(value & opt bool false & info ~doc [ "testing" ])
+    Arg.(value & flag & info ~doc [ "testing" ])
   ;;
 
   let commit =


### PR DESCRIPTION
Cmdliner is a acting a bit weird whether `opt bool false` requires an argument or not, but the right thing is to use `flag` anyway.