### PR TITLE
Add Windows binaries

### DIFF
--- a/.github/workflows/binary-nightly.yaml
+++ b/.github/workflows/binary-nightly.yaml
@@ -44,12 +44,19 @@ jobs:
           - os: macos-15-intel
             name: x86_64-apple-darwin
             installable: .#dune
+            binary: dune
           - os: macos-14
             name: aarch64-apple-darwin
             installable: .#dune
+            binary: dune
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
             installable: .#dune-static
+            binary: dune
+          - os: ubuntu-22.04
+            name: x86_64-unknown-windows
+            installable: .#windows-static
+            binary: dune.exe
 
     # If the latest commit is the same as latest run, don't re-run.
     if: ${{ needs.check_build.outputs.action == 'BUILD' || github.event_name == 'workflow_dispatch' }}
@@ -93,14 +100,14 @@ jobs:
         id: certificate
         uses: actions/attest@v4
         with:
-          subject-path: "result/bin/dune"
+          subject-path: "result/bin/${{ matrix.binary }}"
           show-summary: false
 
       - name: Extract artifact and attestation
         run: |
           mkdir -p ~/build/$ARCHIVE_DIR/
           cp ${{ steps.certificate.outputs.bundle-path }} ~/build
-          cp result/bin/dune ~/build/$ARCHIVE_DIR
+          cp "result/bin/${{ matrix.binary }}" ~/build/$ARCHIVE_DIR
           cp -r $GITHUB_WORKSPACE/dune-binary-distribution/env ~/build/$ARCHIVE_DIR
           cp -r $GITHUB_WORKSPACE/dune-binary-distribution/completions ~/build/$ARCHIVE_DIR
           cp -r $GITHUB_WORKSPACE/dune-binary-distribution/tool-wrappers ~/build/$ARCHIVE_DIR
@@ -124,6 +131,8 @@ jobs:
             name: aarch64-apple-darwin
           - os: ubuntu-22.04
             name: x86_64-unknown-linux-musl
+          - os: windows-2025
+            name: x86_64-unknown-windows
 
     runs-on: ${{ matrix.os }}
     needs: binary

--- a/.github/workflows/binary-nightly.yaml
+++ b/.github/workflows/binary-nightly.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 1 * * *" # Triggers the build at 1:00 UTC time
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check_build:
     name: Check if we need to run the pipeline or not

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -3,18 +3,21 @@ module Target = struct
     | Aarch64_apple_darwin
     | X86_64_apple_darwin
     | X86_64_unknown_linux_musl
+    | X86_64_unknown_windows
   [@@deriving yojson]
 
   let to_string = function
     | Aarch64_apple_darwin -> "aarch64-apple-darwin"
     | X86_64_apple_darwin -> "x86_64-apple-darwin"
     | X86_64_unknown_linux_musl -> "x86_64-unknown-linux-musl"
+    | X86_64_unknown_windows -> "x86_64-unknown-windows"
   ;;
 
   let of_string = function
     | "aarch64-apple-darwin" -> Some Aarch64_apple_darwin
     | "x86_64-apple-darwin" -> Some X86_64_apple_darwin
     | "x86_64-unknown-linux-musl" -> Some X86_64_unknown_linux_musl
+    | "x86_64-unknown-windows" -> Some X86_64_unknown_windows
     | _ -> None
   ;;
 
@@ -22,21 +25,24 @@ module Target = struct
     | Aarch64_apple_darwin -> "Apple macOS (ARM64)"
     | X86_64_apple_darwin -> "Apple macOS (x86-64)"
     | X86_64_unknown_linux_musl -> "Linux (x86-64, musl)"
+    | X86_64_unknown_windows -> "Windows (x86-64)"
   ;;
 
   let to_description = function
     | Aarch64_apple_darwin -> "macOS 11 or later for Apple silicon processors"
     | X86_64_apple_darwin -> "macOS 11 or later for Intel processors"
     | X86_64_unknown_linux_musl -> "Linux for Intel 64-bit processors"
+    | X86_64_unknown_windows -> "Windows for Intel 64-bit processors"
   ;;
 
   let to_triple = function
     | Aarch64_apple_darwin -> "aarch64", "apple", "macOS"
     | X86_64_apple_darwin -> "x86-64", "apple", "macOS"
     | X86_64_unknown_linux_musl -> "x86-64", "unknown", "Linux"
+    | X86_64_unknown_windows -> "x86-64", "unknown", "Windows"
   ;;
 
-  let defaults = [ Aarch64_apple_darwin; X86_64_apple_darwin; X86_64_unknown_linux_musl ]
+  let defaults = [ Aarch64_apple_darwin; X86_64_apple_darwin; X86_64_unknown_linux_musl; X86_64_unknown_windows ]
 end
 
 module Pdate = struct

--- a/test/dune-workspace
+++ b/test/dune-workspace
@@ -1,0 +1,18 @@
+(lang dune 3.22)
+
+(pkg enabled)
+
+(lock_dir
+  ;; platforms supported by binary distribution
+  ;; no need to lock for platforms we don't support
+  ;;
+  ;; need to opt into windows explicitely
+  (solve_for_platforms
+    ((arch x86_64)
+     (os linux))
+    ((arch x86_64)
+     (os macos))
+    ((arch arm64)
+     (os macos))
+    ((arch x86_64)
+     (os win32))))


### PR DESCRIPTION
This PR uses the cross-compiling support implemented by @Alizter to cross-build Windows binaries on Nix. The resulting binary is then tested on "real" Windows.

Currently in draft as building a package fails as installing `flexdll` fails:

```
Error: entry
_build/_private/default/.pkg/flexdll.0.44-3397262cc27cdbe81fa917c723b35e88/source/default_amd64.manifest
in
_build/_private/default/.pkg/flexdll.0.44-3397262cc27cdbe81fa917c723b35e88/source/flexdll.install
does not exist
-> required by
   _build/_private/default/.pkg/flexdll.0.44-3397262cc27cdbe81fa917c723b35e88/target
-> required by
   _build/_private/default/.pkg/ocaml-base-compiler.5.5.0-7a6f8992bfeb9e42ff8bfecdc53fa9a6/target/cookie
-> required by loading the OCaml compiler for context "default"
```