### PR TITLE
Update APT DB to refer to available version of `rclone`

### DIFF
--- a/.github/workflows/binary-nightly.yaml
+++ b/.github/workflows/binary-nightly.yaml
@@ -162,6 +162,7 @@ jobs:
     steps:
       - name: Install rclone
         run: |
+          sudo apt-get update
           sudo apt-get install rclone
 
       - name: Install sandworm external deps

--- a/.github/workflows/binary-stable.yaml
+++ b/.github/workflows/binary-stable.yaml
@@ -187,6 +187,7 @@ jobs:
 
       - name: Install rclone
         run: |
+          sudo apt-get update
           sudo apt-get install rclone
 
       - name: Install dune


### PR DESCRIPTION
The deployment currently fails because the `rclone` Debian package is not on the mirror anymore. This is most likely due to a new version of `rclone` being put on and the old version removed, but the APT database still refers to the older version (`1.60.1+dfsg-3ubuntu0.24.04.5`).

This PR updates both workflows to update the APT database before attempting to install `rclone`. I [tested it on my branch](https://github.com/Leonidas-from-XIV/dune-binary-distribution/actions/runs/30816725929) and while deployment fails (due to missing credentials; as expected) installing `rclone` (`1.60.1+dfsg-3ubuntu0.24.04.6`) succeeds. So I expect that this will fix the deployment error too.